### PR TITLE
Production-ready container + Caddy proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
+SLASHA_ENV=development
 JWT_SECRET=
-SLASHA_PLATFORM_DOMAIN=slasha.app
+SLASHA_PLATFORM_DOMAIN=slasha.localhost

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /app
 FROM chef AS planner
 COPY Cargo.toml Cargo.lock ./
 COPY slasha-server/ ./slasha-server/
-COPY slasha-models/ ./slasha-models/
-COPY slasha-server/git-ssh-handler/ ./slasha-server/git-ssh-handler/
+COPY slasha-cli/ ./slasha-cli/
+COPY slasha-db/ ./slasha-db/
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
@@ -23,8 +23,8 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY Cargo.toml Cargo.lock ./
 COPY slasha-server/ ./slasha-server/
-COPY slasha-models/ ./slasha-models/
-COPY slasha-server/git-ssh-handler/ ./slasha-server/git-ssh-handler/
+COPY slasha-cli/ ./slasha-cli/
+COPY slasha-db/ ./slasha-db/
 COPY --from=frontend-builder /app/web/build/client /app/web/build/client
 RUN cargo build --release -p slasha-server --features bundle \
  && cargo build --release -p git-ssh-handler
@@ -36,13 +36,16 @@ RUN apt-get update && \
 
 RUN mkdir /var/run/sshd \
  && useradd -m slasha \
- && mkdir -p /home/slasha/.ssh \
- && chmod 700 /home/slasha/.ssh \
- && chown -R slasha:slasha /home/slasha/.ssh
+ && install -d -m 0700 -o slasha -g slasha /home/slasha/.ssh \
+ && install -d -m 0755 -o slasha -g slasha /home/slasha/.slasha \
+ && touch /home/slasha/.ssh/.keep /home/slasha/.slasha/.keep \
+ && chown slasha:slasha /home/slasha/.ssh/.keep /home/slasha/.slasha/.keep \
+ && echo "Port 2222" > /etc/ssh/sshd_config.d/slasha.conf
 
 COPY --from=builder /app/target/release/slasha-server /usr/local/bin/slasha-server
 COPY --from=builder /app/target/release/slasha-git-ssh-handler /usr/local/bin/slasha-git-ssh-handler
-RUN chmod +x /usr/local/bin/slasha-server /usr/local/bin/slasha-git-ssh-handler
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/slasha-server /usr/local/bin/slasha-git-ssh-handler /usr/local/bin/docker-entrypoint.sh
 
-EXPOSE 3000 22
-CMD ["/bin/bash", "-c", "/usr/sbin/sshd -D & exec su -s /bin/bash slasha -c 'exec slasha-server'"]
+EXPOSE 3000 2222
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# PID 1 inside the slasha container.
+# Runs sshd (port 2222, for git push) and slasha-server side by side.
+
+set -euo pipefail
+
+# Match the in-container 'docker' group GID to the host's, so the slasha user
+# can talk to the bind-mounted /var/run/docker.sock. The host's GID varies
+# between distros, so we read it at runtime.
+if [[ -S /var/run/docker.sock ]]; then
+  sock_gid=$(stat -c '%g' /var/run/docker.sock)
+  if getent group docker >/dev/null; then
+    groupmod -g "$sock_gid" docker >/dev/null
+  else
+    groupadd -g "$sock_gid" docker >/dev/null
+  fi
+  if ! id -nG slasha | grep -qw docker; then
+    usermod -aG docker slasha
+  fi
+fi
+
+# Run sshd as root in the background. openssh-server's postinstall has already
+# generated host keys at image build time.
+/usr/sbin/sshd -D &
+
+# Drop privileges and run the HTTP server in the foreground.
+exec runuser -u slasha -- /usr/local/bin/slasha-server

--- a/slasha-server/src/assets.rs
+++ b/slasha-server/src/assets.rs
@@ -7,7 +7,7 @@ use mime_guess;
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
-#[folder = "../../web/build/client"]
+#[folder = "../web/build/client"]
 pub struct Assets;
 
 pub async fn static_handler(path: Option<axum::extract::Path<String>>) -> impl IntoResponse {

--- a/slasha-server/src/main.rs
+++ b/slasha-server/src/main.rs
@@ -23,7 +23,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::{
     proxy::container::ensure_caddy_ready,
-    state::{Clients, Config, Runtime, Storage},
+    state::{Clients, Config, Env, Runtime, Storage},
 };
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("../slasha-db/migrations");
@@ -78,7 +78,12 @@ async fn main() -> anyhow::Result<()> {
 
     let (db_path, repos_dir, logs_dir) = setup_dirs();
 
+    let env = Env::from_str_or_default(
+        &std::env::var("SLASHA_ENV").unwrap_or_else(|_| "development".to_string()),
+    );
+
     let config = Config::new(
+        env,
         std::env::var("JWT_SECRET").expect("JWT_SECRET must be set"),
         std::env::var("SLASHA_PLATFORM_DOMAIN").ok(),
         logs_dir.clone(),

--- a/slasha-server/src/proxy/caddy_client.rs
+++ b/slasha-server/src/proxy/caddy_client.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde_json::{Value, json};
 
 use super::{ProxyError, ProxyResult};
+use crate::state::Env;
 
 #[derive(Clone)]
 pub struct CaddyClient {
@@ -17,12 +18,12 @@ pub struct RouteEntry {
 }
 
 impl CaddyClient {
-    pub async fn sync_routes(&self, routes: &[RouteEntry]) -> ProxyResult<()> {
-        let config = Self::build_config(routes);
+    pub async fn sync_routes(&self, routes: &[RouteEntry], env: Env) -> ProxyResult<()> {
+        let config = Self::build_config(routes, env);
         self.load(&config).await
     }
 
-    fn build_config(routes: &[RouteEntry]) -> Value {
+    fn build_config(routes: &[RouteEntry], env: Env) -> Value {
         let mut caddy_routes = Vec::new();
 
         for entry in routes {
@@ -45,33 +46,30 @@ impl CaddyClient {
             }));
         }
 
-        json!({
-            "admin": {
-                "listen": "127.0.0.1:2019"
-            },
-            "apps": {
-                "http": {
-                    "servers": {
-                        "srv0": {
-                            "listen": [":80", ":443"],
-                            "routes": caddy_routes
-                        }
-                    }
-                },
-                "tls": {
-                    "automation": {
-                        "policies": [
-                            {
-                                "issuers": [
-                                    {
-                                        "module": "internal"
-                                    }
-                                ]
-                            }
-                        ]
+        let mut apps = json!({
+            "http": {
+                "servers": {
+                    "srv0": {
+                        "listen": [":80", ":443"],
+                        "routes": caddy_routes
                     }
                 }
             }
+        });
+
+        if !env.is_production() {
+            apps["tls"] = json!({
+                "automation": {
+                    "policies": [
+                        { "issuers": [{ "module": "internal" }] }
+                    ]
+                }
+            });
+        }
+
+        json!({
+            "admin": { "listen": "127.0.0.1:2019" },
+            "apps": apps,
         })
     }
 

--- a/slasha-server/src/proxy/reconcile.rs
+++ b/slasha-server/src/proxy/reconcile.rs
@@ -28,7 +28,10 @@ pub async fn reconcile(clients: &Clients, config: &Config) -> ProxyResult<()> {
         .build();
 
     let containers = clients.docker.list_containers(Some(opts)).await?;
-    let mut routes = Vec::new();
+    let mut routes = vec![RouteEntry {
+        domain: platform_domain.clone(),
+        upstream_port: 3000,
+    }];
 
     for container in containers {
         let labels = match &container.labels {
@@ -56,7 +59,7 @@ pub async fn reconcile(clients: &Clients, config: &Config) -> ProxyResult<()> {
         });
     }
 
-    clients.caddy.sync_routes(&routes).await?;
+    clients.caddy.sync_routes(&routes, config.env).await?;
 
     tracing::info!("Reconciled {} proxy routes", routes.len());
 

--- a/slasha-server/src/state.rs
+++ b/slasha-server/src/state.rs
@@ -68,16 +68,42 @@ impl Runtime {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Env {
+    Development,
+    Production,
+}
+
+impl Env {
+    pub fn from_str_or_default(s: &str) -> Self {
+        match s {
+            "production" => Env::Production,
+            _ => Env::Development,
+        }
+    }
+
+    pub fn is_production(self) -> bool {
+        matches!(self, Env::Production)
+    }
+}
+
 #[derive(Clone)]
 pub struct Config {
+    pub env: Env,
     pub jwt_secret: String,
     pub platform_domain: Option<String>,
     pub logs_dir: PathBuf,
 }
 
 impl Config {
-    pub fn new(jwt_secret: String, platform_domain: Option<String>, logs_dir: PathBuf) -> Self {
+    pub fn new(
+        env: Env,
+        jwt_secret: String,
+        platform_domain: Option<String>,
+        logs_dir: PathBuf,
+    ) -> Self {
         Self {
+            env,
             jwt_secret,
             platform_domain,
             logs_dir,


### PR DESCRIPTION
Makes slasha actually deployable in production. Two commits — one bug fix, one feature commit.

## Why

`make dev-bundle` was broken (RustEmbed path), the Dockerfile referenced a workspace member that doesn't exist (`slasha-models/`), the embedded sshd collided with the host's sshd on port 22, the named volumes initialized as root-owned (so the `slasha` user couldn't write), and the Caddy reconciler had no apex route — so even after fixing all of that, `slasha.com` itself would 404 from Caddy.

Plus the previous Caddy config hardcoded `internal` issuer (self-signed CA → invalid certs in production).

## What

### `fix: rust-embed bundle folder path`

The `#[folder]` was `../../web/build/client`, which RustEmbed resolves relative to `CARGO_MANIFEST_DIR` — putting it one directory above the repo root. Drop one level.

### `feat: production-ready container + caddy proxy`

**Dockerfile / runtime**
- Fix workspace COPY (`slasha-models` → `slasha-db`, add `slasha-cli`)
- Embedded sshd on port `2222` to avoid host-sshd collision (host network mode)
- Pre-create `/home/slasha/{.slasha,.ssh}` with `slasha:slasha` ownership + `.keep` markers, so Docker's volume initialization gives a fresh named volume the right ownership on first mount — no runtime chown hack
- Replace inline `CMD` with `docker-entrypoint.sh`:
  - Aligns the in-container `docker` group GID to the host's `docker.sock` GID at runtime (host distro varies), so the `slasha` user can actually talk to `/var/run/docker.sock`
  - Starts `sshd` in the background, drops to `slasha` via `runuser`

**Proxy**
- Reconciler seeds an apex `platform_domain → 127.0.0.1:3000` route so the dashboard is reachable. Previously only user-app subdomains were routed.

**TLS / env**
- New `SLASHA_ENV` env var (`development` | `production`, default `development`)
- Dev: Caddy uses its internal CA — local runs don't burn Let's Encrypt rate limits or require public DNS
- Prod: `tls` block is omitted from the Caddy config so Caddy defaults to ACME / Let's Encrypt
- `.env.example` now ships `SLASHA_ENV=development` and `SLASHA_PLATFORM_DOMAIN=slasha.localhost` (RFC 6761 reserved TLD — never resolves, so an accidental ACME attempt fails loud rather than silently hammering the real prod-domain quota)

## Test plan

- [x] `cargo check -p slasha-server` clean
- [x] `make dev-bundle` builds (RustEmbed path)
- [x] Production deploy succeeds end-to-end against a Hetzner CCX13
- [x] `https://slasha.com` returns 200 with a valid Let's Encrypt cert (issuer `O=Let's Encrypt, CN=E7`)
- [x] Reconciler logs `Reconciled 1 proxy routes` (the apex)
- [x] Container runs without restart loops; `slasha` user can write to `~/.slasha/repos` and talk to `docker.sock`
- [x] sshd reachable on `:2222` (returns Permission denied for unregistered keys, as expected)