### PR TITLE
Security hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 SLASHA_ENV=development
 JWT_SECRET=
 SLASHA_PLATFORM_DOMAIN=slasha.localhost
+# When true, the dashboard apex domain is NOT routed publicly. Reach the UI
+# via `ssh -L 3000:127.0.0.1:3000 root@<host>` and open http://localhost:3000.
+# App subdomains stay public.
+SLASHA_PRIVATE_MODE=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir /var/run/sshd \
  && install -d -m 0755 -o slasha -g slasha /home/slasha/.slasha \
  && touch /home/slasha/.ssh/.keep /home/slasha/.slasha/.keep \
  && chown slasha:slasha /home/slasha/.ssh/.keep /home/slasha/.slasha/.keep \
- && echo "Port 2222" > /etc/ssh/sshd_config.d/slasha.conf
+ && rm -f /etc/ssh/ssh_host_*
 
 COPY --from=builder /app/target/release/slasha-server /usr/local/bin/slasha-server
 COPY --from=builder /app/target/release/slasha-git-ssh-handler /usr/local/bin/slasha-git-ssh-handler

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security model
+
+slasha is a **single-tenant, self-hosted PaaS**. The trust model assumes the operator running slasha owns the host and is the only person deploying apps to it. This document spells out the security boundaries, what slasha does protect, what it does *not*, and how to deploy it more or less defensively.
+
+## Threat model in one line
+
+> Anyone who logs into slasha can deploy a container on the host. Containers run with access to the docker socket, so **slasha login = root on the host**. Treat the slasha admin password the way you'd treat the host's root SSH key.
+
+## What slasha protects against
+
+- **Network-level eavesdropping** — Caddy auto-issues real Let's Encrypt certs in production (`SLASHA_ENV=production`); HSTS is enabled in production responses.
+- **Password leaks at rest** — passwords are stored as Argon2id hashes (default OWASP-recommended params).
+- **Token forgery** — JWT auth uses HS256 with a 256-bit secret; the verifier pins the algorithm so `alg=none` and key-confusion attacks don't apply.
+- **User enumeration** — `/login` returns the same error message for unknown email and bad password.
+- **First-boot squatting** — `/signup` is locked permanently after the first admin is created. `/signup` and `/login` are rate-limited per source IP (3/min and 10/min respectively).
+
+## What slasha does NOT currently protect against
+
+These are real gaps. Treat them as load-bearing constraints when planning your deploy.
+
+- **No MFA / WebAuthn.** Login is password-only. The login form is the gate to everything; if your password is weak, an attacker who breaks it owns the host. *Choose a strong password.* MFA is a roadmap item.
+- **JWT revocation.** Tokens are valid for 30 days from issue. There is no revocation list, so a leaked token stays valid until expiry — even after a password change.
+- **Audit log.** Deployments, logins, and admin changes are not separately logged for forensic review.
+- **Container isolation.** User-app containers spawned by slasha do not currently apply capability drops, seccomp profiles, user namespaces, or memory/CPU limits. For a self-hosted single-tenant install where you trust your own apps, this is fine. *Do not run untrusted third-party apps.*
+- **Docker socket exposure.** The slasha container has `/var/run/docker.sock` mounted read-write. Any RCE in slasha-server escalates to root on the host. The high-level mitigation is "don't expose the slasha login to the public internet if you don't need to" — see `SLASHA_PRIVATE_MODE` below.
+
+## Deployment recommendations
+
+Pick one of the three based on your tolerance for public-facing auth surface.
+
+### 1. Public dashboard (default)
+
+DNS for both `your.domain` and `*.your.domain` points at the host. Caddy serves the dashboard publicly with a real cert; `/login` is rate-limited; you log in with your password.
+
+This is the simplest setup and what the project README walks you through. Fine for solo operators with strong passwords. **Not recommended for production until MFA lands** if your password might be guessable.
+
+### 2. Private dashboard, public apps
+
+Set `SLASHA_PRIVATE_MODE=true`. The apex domain is omitted from Caddy's routes — the dashboard is no longer reachable from the internet. App subdomains (`<slug>.your.domain`) stay public so users hitting your deployed apps still work.
+
+To use the dashboard yourself:
+```sh
+ssh -L 3000:127.0.0.1:3000 root@your-host
+# then open http://localhost:3000 in your browser
+```
+
+This removes the auth surface from the internet entirely. Recommended for any host you don't actively administrate from a phone.
+
+### 3. Behind a VPN
+
+Bind your host's public ports only to your VPN (Tailscale, WireGuard, etc.). All slasha traffic — apps, dashboard, git push — flows over the VPN. Maximally restrictive; only suitable when your app users are also on your VPN.
+
+## Hardening the host itself
+
+The deployment scaffold ships with these enabled:
+
+- `ufw` deny-all-incoming except `22` (host ssh), `80`/`443` (Caddy), `2222` (slasha git push).
+- `fail2ban` with jails for both host sshd and the container's git-push sshd.
+- sshd host keys persist in a Docker volume across rebuilds (clients won't see "host key changed" warnings on every deploy).
+- Caddy adds `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and (in production) `Strict-Transport-Security` to all responses.
+
+## Rotating the JWT secret
+
+Rotating `JWT_SECRET` invalidates every existing session immediately. Useful if you suspect a token leak.
+
+```sh
+# in your slasha-infra repo (or wherever your prod env lives)
+new=$(openssl rand -hex 32)
+sed -i.bak "s/^JWT_SECRET=.*/JWT_SECRET=$new/" .env.production && rm .env.production.bak
+./deploy.sh --no-build
+```
+
+## Reporting security issues
+
+Please email **kamranahmed.se@gmail.com** with details. Don't open public issues for security-sensitive reports.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,8 +20,36 @@ if [[ -S /var/run/docker.sock ]]; then
   fi
 fi
 
-# Run sshd as root in the background. openssh-server's postinstall has already
-# generated host keys at image build time.
+# Persist sshd host keys in the slasha-data named volume. Without this, every
+# image rebuild would generate fresh keys and clients would see "host key
+# changed" warnings on git push — training people to ignore those warnings is
+# a real MITM risk.
+HOST_KEY_DIR=/home/slasha/.slasha/sshd-host-keys
+mkdir -p "$HOST_KEY_DIR"
+chmod 700 "$HOST_KEY_DIR"
+for type in rsa ecdsa ed25519; do
+  key="$HOST_KEY_DIR/ssh_host_${type}_key"
+  if [[ ! -f "$key" ]]; then
+    ssh-keygen -q -t "$type" -N "" -f "$key" -C "slasha-host-${type}"
+  fi
+done
+chown -R slasha:slasha "$HOST_KEY_DIR"
+
+# sshd reads /etc/ssh/sshd_config.d/*.conf in addition to the main config.
+{
+  echo "Port 2222"
+  echo "AllowUsers slasha"
+  echo "PermitRootLogin no"
+  echo "PasswordAuthentication no"
+  echo "ChallengeResponseAuthentication no"
+  echo "KbdInteractiveAuthentication no"
+  echo "PubkeyAuthentication yes"
+  for type in rsa ecdsa ed25519; do
+    echo "HostKey $HOST_KEY_DIR/ssh_host_${type}_key"
+  done
+} > /etc/ssh/sshd_config.d/slasha.conf
+
+# Run sshd as root in the background.
 /usr/sbin/sshd -D &
 
 # Drop privileges and run the HTTP server in the foreground.

--- a/slasha-server/src/extractors/git.rs
+++ b/slasha-server/src/extractors/git.rs
@@ -81,8 +81,6 @@ where
             .split_once(':')
             .ok_or(GitError::InvalidCredentials)?;
 
-        tracing::info!("Git auth: {} {}", email, password);
-
         let user = UserRepo::find_by_email(&state.storage.db_pool, email)
             .await?
             .ok_or(GitError::InvalidCredentials)?;
@@ -95,7 +93,7 @@ where
             .await
             .map_err(|_| GitError::RepoNotFound)?;
 
-        tracing::info!("verified user");
+        tracing::info!(user_id = %user.id, app_slug = %app.slug, "git auth ok");
 
         Ok(GitAuth { user, app })
     }

--- a/slasha-server/src/main.rs
+++ b/slasha-server/src/main.rs
@@ -81,12 +81,17 @@ async fn main() -> anyhow::Result<()> {
     let env = Env::from_str_or_default(
         &std::env::var("SLASHA_ENV").unwrap_or_else(|_| "development".to_string()),
     );
+    let private_mode = matches!(
+        std::env::var("SLASHA_PRIVATE_MODE").as_deref(),
+        Ok("1") | Ok("true") | Ok("yes")
+    );
 
     let config = Config::new(
         env,
         std::env::var("JWT_SECRET").expect("JWT_SECRET must be set"),
         std::env::var("SLASHA_PLATFORM_DOMAIN").ok(),
         logs_dir.clone(),
+        private_mode,
     );
 
     let docker =

--- a/slasha-server/src/middleware/mod.rs
+++ b/slasha-server/src/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod admin;
+pub mod rate_limit;

--- a/slasha-server/src/middleware/rate_limit.rs
+++ b/slasha-server/src/middleware/rate_limit.rs
@@ -1,0 +1,100 @@
+use std::{
+    net::IpAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use axum::{
+    extract::{Request, State},
+    http::{HeaderMap, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use dashmap::DashMap;
+
+#[derive(Clone, Copy)]
+pub struct RateLimit {
+    pub max_requests: u32,
+    pub window: Duration,
+}
+
+#[derive(Clone)]
+pub struct RateLimiter {
+    inner: Arc<RateLimiterInner>,
+}
+
+struct RateLimiterInner {
+    limit: RateLimit,
+    buckets: DashMap<IpAddr, Bucket>,
+}
+
+struct Bucket {
+    count: u32,
+    window_start: Instant,
+}
+
+impl RateLimiter {
+    pub fn new(limit: RateLimit) -> Self {
+        Self {
+            inner: Arc::new(RateLimiterInner {
+                limit,
+                buckets: DashMap::new(),
+            }),
+        }
+    }
+
+    fn check(&self, ip: IpAddr) -> bool {
+        let now = Instant::now();
+        let window = self.inner.limit.window;
+        let max = self.inner.limit.max_requests;
+
+        let mut entry = self.inner.buckets.entry(ip).or_insert(Bucket {
+            count: 0,
+            window_start: now,
+        });
+
+        if now.duration_since(entry.window_start) > window {
+            entry.count = 0;
+            entry.window_start = now;
+        }
+
+        if entry.count >= max {
+            return false;
+        }
+        entry.count += 1;
+        true
+    }
+}
+
+pub async fn rate_limit_middleware(
+    State(limiter): State<RateLimiter>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let ip = client_ip(request.headers());
+
+    if let Some(ip) = ip {
+        if !limiter.check(ip) {
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                [(header::RETRY_AFTER, "60")],
+                "rate limit exceeded\n",
+            )
+                .into_response();
+        }
+    }
+
+    next.run(request).await
+}
+
+/// Slasha-server runs behind the slasha-proxy Caddy on the same host (loopback),
+/// so the TCP peer is always 127.0.0.1 — useless for rate-limiting. The real
+/// client IP is in `X-Forwarded-For`, set by Caddy.
+fn client_ip(headers: &HeaderMap) -> Option<IpAddr> {
+    headers
+        .get("x-forwarded-for")
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(str::trim)
+        .and_then(|s| s.parse().ok())
+}

--- a/slasha-server/src/proxy/caddy_client.rs
+++ b/slasha-server/src/proxy/caddy_client.rs
@@ -24,6 +24,7 @@ impl CaddyClient {
     }
 
     fn build_config(routes: &[RouteEntry], env: Env) -> Value {
+        let security_headers = Self::security_headers(env);
         let mut caddy_routes = Vec::new();
 
         for entry in routes {
@@ -34,6 +35,10 @@ impl CaddyClient {
                     }
                 ],
                 "handle": [
+                    {
+                        "handler": "headers",
+                        "response": { "set": security_headers }
+                    },
                     {
                         "handler": "reverse_proxy",
                         "upstreams": [
@@ -71,6 +76,26 @@ impl CaddyClient {
             "admin": { "listen": "127.0.0.1:2019" },
             "apps": apps,
         })
+    }
+
+    fn security_headers(env: Env) -> Value {
+        let mut headers = serde_json::Map::new();
+        headers.insert("X-Content-Type-Options".into(), json!(["nosniff"]));
+        headers.insert("X-Frame-Options".into(), json!(["DENY"]));
+        headers.insert(
+            "Referrer-Policy".into(),
+            json!(["strict-origin-when-cross-origin"]),
+        );
+        headers.insert("Permissions-Policy".into(), json!(["interest-cohort=()"]));
+        // HSTS only in production — sending it from a self-signed dev cert
+        // pins browsers to a broken HTTPS state.
+        if env.is_production() {
+            headers.insert(
+                "Strict-Transport-Security".into(),
+                json!(["max-age=31536000; includeSubDomains"]),
+            );
+        }
+        Value::Object(headers)
     }
 
     async fn load(&self, config: &Value) -> ProxyResult<()> {

--- a/slasha-server/src/proxy/reconcile.rs
+++ b/slasha-server/src/proxy/reconcile.rs
@@ -28,10 +28,13 @@ pub async fn reconcile(clients: &Clients, config: &Config) -> ProxyResult<()> {
         .build();
 
     let containers = clients.docker.list_containers(Some(opts)).await?;
-    let mut routes = vec![RouteEntry {
-        domain: platform_domain.clone(),
-        upstream_port: 3000,
-    }];
+    let mut routes = Vec::new();
+    if !config.private_mode {
+        routes.push(RouteEntry {
+            domain: platform_domain.clone(),
+            upstream_port: 3000,
+        });
+    }
 
     for container in containers {
         let labels = match &container.labels {

--- a/slasha-server/src/routing/api/auth.rs
+++ b/slasha-server/src/routing/api/auth.rs
@@ -1,5 +1,7 @@
+use std::time::Duration;
+
 use axum::{
-    Json, Router,
+    Json, Router, middleware,
     extract::State,
     response::IntoResponse,
     routing::{get, post},
@@ -13,15 +15,40 @@ use crate::{
     auth::{TokenPayload, create_jwt, hash_password, verify_password},
     error::{HttpError, HttpResult},
     extractors::auth::AuthUser,
+    middleware::rate_limit::{RateLimit, RateLimiter, rate_limit_middleware},
     state::{AppState, Config, Storage},
 };
 
 const EXP_TIME: usize = 30 * 24 * 60 * 60;
 
 pub fn router() -> Router<AppState> {
+    let login_limiter = RateLimiter::new(RateLimit {
+        max_requests: 10,
+        window: Duration::from_secs(60),
+    });
+    let signup_limiter = RateLimiter::new(RateLimit {
+        max_requests: 3,
+        window: Duration::from_secs(60),
+    });
+
+    let limited = Router::new()
+        .route(
+            "/signup",
+            post(signup).layer(middleware::from_fn_with_state(
+                signup_limiter,
+                rate_limit_middleware,
+            )),
+        )
+        .route(
+            "/login",
+            post(login).layer(middleware::from_fn_with_state(
+                login_limiter,
+                rate_limit_middleware,
+            )),
+        );
+
     Router::new()
-        .route("/signup", post(signup))
-        .route("/login", post(login))
+        .merge(limited)
         .route("/me", get(me))
         .route("/status", get(status))
 }

--- a/slasha-server/src/state.rs
+++ b/slasha-server/src/state.rs
@@ -93,6 +93,10 @@ pub struct Config {
     pub jwt_secret: String,
     pub platform_domain: Option<String>,
     pub logs_dir: PathBuf,
+    /// When true, the dashboard apex route is omitted from the public Caddy
+    /// proxy. App subdomains stay public; the operator reaches the UI via
+    /// `ssh -L 3000:127.0.0.1:3000` (or any other tunnel).
+    pub private_mode: bool,
 }
 
 impl Config {
@@ -101,12 +105,14 @@ impl Config {
         jwt_secret: String,
         platform_domain: Option<String>,
         logs_dir: PathBuf,
+        private_mode: bool,
     ) -> Self {
         Self {
             env,
             jwt_secret,
             platform_domain,
             logs_dir,
+            private_mode,
         }
     }
 }


### PR DESCRIPTION
Stacked on #2 (`prod-deploy`). Fixes audit findings from a security review of the slasha install for self-hosted deploys.

## Six commits, smallest blast radius first

### 🔴 `fix: stop logging plaintext password in git auth extractor`
`slasha-server/src/extractors/git.rs:84` was emitting

```rust
tracing::info!(\"Git auth: {} {}\", email, password);
```

on every git push. Logs flow to docker / aggregators / disk, so the password ended up persisted alongside the user identifier. Removed.

### `feat: persist sshd host keys + harden container sshd`

- Host keys live in the `slasha-data` named volume at `/home/slasha/.slasha/sshd-host-keys/`. Generated on first boot, reused thereafter — image rebuilds no longer rotate them. Kills the recurring "host key changed" warning on `git push` (which trains users to click through MITM warnings).
- Container sshd is now key-only and locked to the `slasha` user (`AllowUsers slasha`, `PasswordAuthentication no`, `PermitRootLogin no`, ...). Brute force can't succeed regardless of who reaches `:2222`, so no fail2ban needed for that listener.

### `feat: emit security headers from caddy`

Every reverse-proxy route now sets `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`. In production (`SLASHA_ENV=production`), Caddy additionally sends `Strict-Transport-Security` with a 1-year max-age. HSTS is omitted in dev because pinning a browser to HTTPS while serving a self-signed cert breaks the origin.

### `feat: rate-limit /login and /signup`

Per-IP fixed-window limiter:
- `POST /api/auth/login`: 10 req/min
- `POST /api/auth/signup`: 3 req/min

Returns 429 with `Retry-After: 60`. Implementation is a small middleware backed by the existing `dashmap` dep — no new crate. Client IP is read from `X-Forwarded-For` (Caddy sets it) since slasha-server's TCP peer is always loopback in production.

### `feat: SLASHA_PRIVATE_MODE for hidden dashboard`

When `SLASHA_PRIVATE_MODE=true`, the apex platform domain is omitted from the Caddy config. Dashboard becomes unreachable from the public internet; app subdomains stay public. Operator reaches the UI via `ssh -L 3000:127.0.0.1:3000 root@host`. Useful for paranoid deploys until MFA lands.

### `docs: add SECURITY.md threat model`

Spells out: slasha login = root on the host (because of docker.sock mount), what's protected, what isn't, three deployment postures (public / `SLASHA_PRIVATE_MODE` / VPN-behind), and how to rotate `JWT_SECRET`.

## What's still open (not in this PR)

- **MFA / TOTP** — substantial separate effort (DB migration, TOTP crate, enrollment + login challenge UI, recovery codes). Tracked as a known gap in `SECURITY.md`.
- **JWT revocation list** — tokens are valid 30 days from issue with no way to invalidate before then.
- **Audit log** — deployments / logins / admin changes aren't separately logged.
- **Per-app container resource limits + capability drops** — deferred under the "single-tenant means you trust your own apps" assumption from `SECURITY.md`.

## Test plan

- [x] `cargo check -p slasha-server` clean
- [x] Deployed end-to-end against the production Hetzner CCX13
- [x] All 5 security headers present on `https://slasha.com` response
- [x] HSTS only emitted in production (verified `SLASHA_ENV` gate)
- [x] Rate limiter: 10×400 then 429 on rapid `/login` POSTs (curl loop in deploy)
- [x] sshd host keys land in `slasha-data` volume; survive container recreate
- [x] Container sshd rejects password auth attempts
- [x] No more password in `docker logs slasha`