### PR TITLE
ci: deploy to production via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          git clone --depth 1 git@github.com:nilbuild/slasha-infra.git ../slasha-infra
+          git clone --depth 1 git@github.com:slashacom/slasha-infra.git ../slasha-infra
 
       - name: Install prod SSH key
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,31 +15,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Check out slasha
-        uses: actions/checkout@v4
-
       - name: Set up SSH agent (slasha-infra deploy key)
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.INFRA_DEPLOY_KEY }}
 
-      - name: Check out slasha-infra
+      - name: Clone slasha-infra
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          git clone --depth 1 git@github.com:slashacom/slasha-infra.git ../slasha-infra
-
-      - name: Install prod SSH key
-        env:
-          PROD_SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
-        run: |
-          install -m 700 -d ~/.ssh
-          install -m 600 /dev/null ~/.ssh/id_ed25519
-          printf '%s\n' "$PROD_SSH_KEY" > ~/.ssh/id_ed25519
+          git clone --depth 1 git@github.com:slashacom/slasha-infra.git
 
       - name: Deploy
-        working-directory: ../slasha-infra
         env:
-          SLASHA_HOST: ${{ vars.SLASHA_HOST }}
-          SLASHA_SRC: ${{ github.workspace }}
+          SLASHA_REF: ${{ github.sha }}
+        working-directory: slasha-infra
         run: ./deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           SLASHA_REF: ${{ github.sha }}
         working-directory: slasha-infra
-        run: ./deploy.sh
+        run: ./scripts/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy to production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Serialize deploys: never run two simultaneously, never cancel one in flight.
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out slasha
+        uses: actions/checkout@v4
+
+      - name: Set up SSH agent (slasha-infra deploy key)
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.INFRA_DEPLOY_KEY }}
+
+      - name: Check out slasha-infra
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          git clone --depth 1 git@github.com:nilbuild/slasha-infra.git ../slasha-infra
+
+      - name: Install prod SSH key
+        env:
+          PROD_SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          install -m 600 /dev/null ~/.ssh/id_ed25519
+          printf '%s\n' "$PROD_SSH_KEY" > ~/.ssh/id_ed25519
+
+      - name: Deploy
+        working-directory: ../slasha-infra
+        env:
+          SLASHA_HOST: ${{ vars.SLASHA_HOST }}
+          SLASHA_SRC: ${{ github.workspace }}
+        run: ./deploy.sh


### PR DESCRIPTION
Adds `.github/workflows/deploy.yml`. On push to `main` (and via `workflow_dispatch`), runs `slasha-infra/deploy.sh` against the production host.

## Auth flow

| Secret / var       | Where it comes from                             | What it's used for                               |
|--------------------|-------------------------------------------------|--------------------------------------------------|
| `INFRA_DEPLOY_KEY` | ed25519 keypair generated by setup script       | ssh-agent → `git clone` the private slasha-infra |
| `PROD_SSH_KEY`     | ed25519 keypair generated by setup script       | written to `~/.ssh/id_ed25519` for ssh/scp/rsync |
| `SLASHA_HOST`      | `vars` on this repo                             | passed through to `deploy.sh`                    |

The two secrets and the variable are all wired up by `slasha-infra/setup-github-deploy.sh` (which uses `gh` CLI to register the deploy key on `nilbuild/slasha-infra` and push the secrets/var to this repo). It's already been run, so the workflow can run as soon as this PR merges.

## Concurrency

```yaml
concurrency:
  group: production-deploy
  cancel-in-progress: false
```

Two pushes back-to-back queue serially. A deploy in flight is never killed mid-build.

## Merge order matters

**This PR is independent of #2 and #3, but the order you merge in determines whether the first auto-deploy succeeds.**

The workflow runs `deploy.sh`, which does `docker compose build`. The Dockerfile on `main` (without #2) references `slasha-models/` which doesn't exist in the workspace — the build fails. `set -e` in `deploy.sh` makes the workflow exit non-zero before `docker compose up`, so **the running container on prod is untouched** — no rollback, just a failed CI run.

Recommended order:

1. Merge #2 (`prod-deploy`) — fixes the Dockerfile so the first auto-deploy succeeds.
2. Merge #3 (`security-hardening`) — adds the security work on top.
3. Merge this PR — first push to `main` after this lands triggers an auto-deploy, which pulls #2 + #3 to prod via CI.

If you merge this one first, you'll just see a red CI run until #2 lands. Production keeps running the manually-deployed image (the security-hardened one) the whole time.

## Verify after merge

```bash
gh run list -R slashacom/slasha -w deploy.yml -L 3
gh run watch -R slashacom/slasha
curl -sI https://slasha.com/   # should still 200 with all the security headers
```