### PR TITLE
chore: update infra references from slasha-server binary to bundled CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=frontend-builder /app/web/build/client /app/web/build/client
 RUN cargo build --release -p slasha-cli --features serve-bundle
 
 FROM debian:bookworm-slim AS runtime
-# docker-ce-cli + docker-buildx-plugin are required: slasha-server shells out
+# docker-ce-cli + docker-buildx-plugin are required: `slasha serve` shells out
 # to `docker buildx build` for both Dockerfile and Railpack build paths
 # (talks to the host daemon via the bind-mounted /var/run/docker.sock).
 RUN apt-get update && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # PID 1 inside the slasha container.
-# Runs sshd (port 2222, for git push) and slasha-server side by side.
+# Runs sshd (port 2222, for git push) and `slasha serve` side by side.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- The server is no longer a separate binary — it ships as the `slasha` CLI built with `--features serve-bundle` and runs via `slasha serve` (commit 2d8408d).
- Updates `docker-entrypoint.sh` and `Dockerfile` comments that still described the old separate-binary topology.

## Test plan
- [x] `cargo check -p slasha-cli --features serve-bundle` passes
- [ ] `docker compose build` still succeeds
- [ ] Container starts and `curl http://127.0.0.1:3000/` responds