### PR TITLE
fix: install libdbus-1-dev in builder so keyring crate compiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,12 @@ COPY web/ .
 RUN NODE_ENV=production bun run build
 
 FROM lukemathwalker/cargo-chef:latest-rust-slim-bookworm AS chef
+# libdbus-1-dev: keyring crate's `sync-secret-service` feature pulls in
+# libdbus-sys on Linux. The keyring is only used by the CLI on user
+# laptops (it has no working DBus session inside the container), but
+# the dep still has to compile when we build the bundled binary.
 RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev libsqlite3-dev && \
+    apt-get install -y pkg-config libssl-dev libsqlite3-dev libdbus-1-dev && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Docker build is failing on `cargo chef cook` with `system library dbus-1 was not found` while compiling `libdbus-sys`.
- Root cause: the `keyring` crate enables `sync-secret-service` on Linux, which depends on `libdbus-sys`. Since 2d8408d bundled the CLI into the image, this dep now has to compile inside the build stage.
- Fix: add `libdbus-1-dev` to the `chef` base layer's apt install (alongside the existing `pkg-config`, `libssl-dev`, `libsqlite3-dev`).

The keyring isn't actually used inside the container (no DBus session); it's CLI auth-token storage for user laptops. We could feature-gate it out of `serve-bundle` later, but for now the one-line apt fix unblocks the build.

## Test plan
- [ ] CI image build passes
- [ ] `make deploy` succeeds end-to-end