### PR TITLE
fix: skip keyring read on serve / git-ssh startup

### DIFF
--- a/slasha-cli/src/app_env.rs
+++ b/slasha-cli/src/app_env.rs
@@ -18,7 +18,10 @@ pub async fn dispatch(state: &AppState, slug: &str, cmd: AppEnvCommand) -> Resul
 }
 
 pub async fn handle_list(state: &AppState, slug: &str) -> Result<()> {
-    let env_data = state.client.get(&format!("/api/apps/{}/env", slug)).await?;
+    let env_data = state
+        .api_client
+        .get(&format!("/api/apps/{}/env", slug))
+        .await?;
 
     let vars: HashMap<String, String> =
         serde_json::from_value(env_data["env_vars"].clone()).context("Failed to parse env vars")?;
@@ -50,7 +53,7 @@ pub async fn handle_set(state: &AppState, slug: &str, pairs: &[String]) -> Resul
     }
 
     let update_res = state
-        .client
+        .api_client
         .put(
             &format!("/api/apps/{}/env", slug),
             &json!({ "vars": current }),
@@ -74,7 +77,7 @@ pub async fn handle_unset(state: &AppState, slug: &str, keys: &[String]) -> Resu
     }
 
     let update_res = state
-        .client
+        .api_client
         .put(
             &format!("/api/apps/{}/env", slug),
             &json!({ "vars": current }),
@@ -89,7 +92,10 @@ pub async fn handle_unset(state: &AppState, slug: &str, keys: &[String]) -> Resu
 }
 
 async fn fetch_vars(state: &AppState, slug: &str) -> Result<HashMap<String, String>> {
-    let env_data = state.client.get(&format!("/api/apps/{}/env", slug)).await?;
+    let env_data = state
+        .api_client
+        .get(&format!("/api/apps/{}/env", slug))
+        .await?;
 
     serde_json::from_value(env_data["env_vars"].clone()).context("Failed to parse env vars")
 }

--- a/slasha-cli/src/apps.rs
+++ b/slasha-cli/src/apps.rs
@@ -12,14 +12,14 @@ use crate::{
 fn git_remote_url(state: &AppState, slug: &str) -> String {
     format!(
         "{}/git/{}",
-        state.client.url("").trim_end_matches('/'),
+        state.api_client.url("").trim_end_matches('/'),
         slug
     )
 }
 
 fn ssh_git_url(state: &AppState, slug: &str) -> String {
     let host = state
-        .client
+        .api_client
         .url("")
         .trim_end_matches('/')
         .trim_start_matches("http://")
@@ -51,7 +51,7 @@ fn print_app(state: &AppState, app: &App) {
 }
 
 pub async fn handle_list(state: &AppState) -> Result<()> {
-    let body = state.client.get("/api/apps").await?;
+    let body = state.api_client.get("/api/apps").await?;
 
     let apps: Vec<App> =
         serde_json::from_value(body["apps"].clone()).context("Failed to parse apps")?;
@@ -81,7 +81,7 @@ pub async fn handle_list(state: &AppState) -> Result<()> {
 
 pub async fn handle_create(state: &AppState, name: &str) -> Result<()> {
     let body = state
-        .client
+        .api_client
         .post("/api/apps", &json!({ "name": name }))
         .await?;
 
@@ -96,7 +96,7 @@ pub async fn handle_create(state: &AppState, name: &str) -> Result<()> {
 }
 
 pub async fn handle_info(state: &AppState, slug: &str) -> Result<()> {
-    let body = state.client.get(&format!("/api/apps/{}", slug)).await?;
+    let body = state.api_client.get(&format!("/api/apps/{}", slug)).await?;
 
     let app: App = serde_json::from_value(body["app"].clone()).context("Failed to parse app")?;
 
@@ -119,11 +119,18 @@ pub async fn handle_delete(state: &AppState, slug: &str, yes: bool) -> Result<()
         return Ok(());
     }
 
-    state.client.delete(&format!("/api/apps/{}", slug)).await?;
+    state
+        .api_client
+        .delete(&format!("/api/apps/{}", slug))
+        .await?;
 
-    output(state.output_mode, &json!({ "ok": true, "slug": slug }), || {
-        cli_success(format!("App {} deleted.", slug));
-    })?;
+    output(
+        state.output_mode,
+        &json!({ "ok": true, "slug": slug }),
+        || {
+            cli_success(format!("App {} deleted.", slug));
+        },
+    )?;
 
     Ok(())
 }
@@ -132,7 +139,7 @@ pub async fn handle_link(state: &AppState, app_flag: Option<String>) -> Result<(
     let slug = match app_flag {
         Some(s) => s,
         None => {
-            let body = state.client.get("/api/apps").await?;
+            let body = state.api_client.get("/api/apps").await?;
 
             let apps: Vec<App> =
                 serde_json::from_value(body["apps"].clone()).context("Failed to parse apps")?;
@@ -146,18 +153,22 @@ pub async fn handle_link(state: &AppState, app_flag: Option<String>) -> Result<(
         }
     };
 
-    state.client.get(&format!("/api/apps/{}", slug)).await?;
+    state.api_client.get(&format!("/api/apps/{}", slug)).await?;
 
     let mut config = Config::load().unwrap_or_default();
     config.app = Some(slug.clone());
     config.save()?;
 
-    output(state.output_mode, &json!({ "ok": true, "slug": slug }), || {
-        cli_success(format!(
-            "Linked current directory to app '{}' in slasha.toml",
-            slug
-        ));
-    })?;
+    output(
+        state.output_mode,
+        &json!({ "ok": true, "slug": slug }),
+        || {
+            cli_success(format!(
+                "Linked current directory to app '{}' in slasha.toml",
+                slug
+            ));
+        },
+    )?;
 
     Ok(())
 }

--- a/slasha-cli/src/auth.rs
+++ b/slasha-cli/src/auth.rs
@@ -28,7 +28,7 @@ struct MeResponse {
 
 async fn check_has_admin(state: &AppState) -> Result<bool> {
     let status: StatusResponse =
-        serde_json::from_value(state.client.get("/api/auth/status").await?)
+        serde_json::from_value(state.api_client.get("/api/auth/status").await?)
             .context("Failed to parse status")?;
 
     Ok(status.has_admin)
@@ -58,7 +58,7 @@ pub async fn handle_login(state: &AppState) -> Result<()> {
 
     let auth: AuthResponse = match serde_json::from_value(
         state
-            .client
+            .api_client
             .post(
                 "/api/auth/login",
                 &json!({ "email": email, "password": password }),
@@ -98,7 +98,7 @@ async fn handle_signup(state: &AppState) -> Result<()> {
 
     let auth: AuthResponse = match serde_json::from_value(
         state
-            .client
+            .api_client
             .post(
                 "/api/auth/signup",
                 &json!({ "email": email, "password": password }),
@@ -138,7 +138,7 @@ pub async fn handle_logout(state: &AppState) -> Result<()> {
 }
 
 pub async fn handle_me(state: &AppState) -> Result<()> {
-    let me: MeResponse = serde_json::from_value(state.client.get("/api/auth/me").await?)
+    let me: MeResponse = serde_json::from_value(state.api_client.get("/api/auth/me").await?)
         .context("Failed to parse me response")?;
 
     output(state.output_mode, &me.user, || {
@@ -151,7 +151,7 @@ pub async fn handle_me(state: &AppState) -> Result<()> {
 }
 
 pub async fn handle_status(state: &AppState) -> Result<()> {
-    let health = state.client.get("/api/health").await?;
+    let health = state.api_client.get("/api/health").await?;
 
     output(state.output_mode, &health, || {
         cli_success(format!(

--- a/slasha-cli/src/deployments.rs
+++ b/slasha-cli/src/deployments.rs
@@ -46,7 +46,7 @@ pub async fn handle_trigger(state: &AppState, slug: &str, commit: Option<String>
     };
 
     let payload = match state
-        .client
+        .api_client
         .post(&format!("/api/apps/{}/deployments", slug), &payload)
         .await
     {
@@ -93,7 +93,7 @@ fn format_status(status: DeploymentStatus) -> String {
 
 pub async fn handle_list(state: &AppState, slug: &str) -> Result<()> {
     let deployments_data = state
-        .client
+        .api_client
         .get(&format!("/api/apps/{}/deployments", slug))
         .await?;
 
@@ -132,21 +132,12 @@ pub async fn handle_logs(
     let deployment_id = resolve_deployment_id(state, slug, deployment_id).await?;
 
     let res = state
-        .client
+        .api_client
         .get_stream(&format!(
             "/api/apps/{}/deployments/{}/logs",
             slug, deployment_id
         ))
         .await?;
-
-    if !res.status().is_success() {
-        let body: serde_json::Value = res.json().await.context("Failed to parse response body")?;
-        let msg = body["error"]
-            .as_str()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| body.to_string());
-        anyhow::bail!("{}", msg);
-    }
 
     let mut stream = res.bytes_stream().eventsource();
 
@@ -173,6 +164,7 @@ pub async fn handle_logs(
                     )?;
                 }
             }
+
             Err(e) => {
                 cli_error(format!("Stream error: {}", e));
                 break;
@@ -191,7 +183,7 @@ pub async fn handle_stop(
     let deployment_id = resolve_deployment_id(state, slug, deployment_id).await?;
 
     state
-        .client
+        .api_client
         .post(
             &format!("/api/apps/{}/deployments/{}/stop", slug, deployment_id),
             &json!({}),
@@ -213,7 +205,7 @@ pub async fn handle_restart(
     let deployment_id = resolve_deployment_id(state, slug, deployment_id).await?;
 
     state
-        .client
+        .api_client
         .post(
             &format!("/api/apps/{}/deployments/{}/restart", slug, deployment_id),
             &json!({}),
@@ -235,7 +227,7 @@ pub async fn handle_redeploy(
     let deployment_id = resolve_deployment_id(state, slug, deployment_id).await?;
 
     let payload = state
-        .client
+        .api_client
         .post(
             &format!("/api/apps/{}/deployments/{}/redeploy", slug, deployment_id),
             &json!({}),
@@ -276,7 +268,7 @@ pub async fn handle_delete(
     }
 
     state
-        .client
+        .api_client
         .delete(&format!("/api/apps/{}/deployments/{}", slug, deployment_id))
         .await?;
 
@@ -298,7 +290,7 @@ async fn resolve_deployment_id(
     }
 
     let deployments_data = state
-        .client
+        .api_client
         .get(&format!("/api/apps/{}/deployments", slug))
         .await?;
 

--- a/slasha-cli/src/git_ssh.rs
+++ b/slasha-cli/src/git_ssh.rs
@@ -1,7 +1,4 @@
-use std::{
-    env,
-    process::{Command, Stdio},
-};
+use std::{env, process::Command};
 
 use anyhow::{Context, Result};
 use slasha_db::{

--- a/slasha-cli/src/http.rs
+++ b/slasha-cli/src/http.rs
@@ -5,7 +5,6 @@ use crate::{config::Config, token::get_auth_token};
 pub struct ApiClient {
     client: reqwest::Client,
     base_url: String,
-    auth_token: Option<String>,
 }
 
 impl ApiClient {
@@ -14,12 +13,12 @@ impl ApiClient {
         let client = reqwest::Client::builder()
             .build()
             .context("Failed to build HTTP client")?;
+
         Ok(Self {
             client,
             base_url: config
                 .base_url
                 .unwrap_or("http://localhost:3000".to_string()),
-            auth_token: get_auth_token()?,
         })
     }
 
@@ -36,10 +35,25 @@ impl ApiClient {
     }
 
     pub async fn get_stream(&self, path: &str) -> Result<reqwest::Response> {
-        self.apply_auth(self.client.get(self.url(path)))
+        let res = self
+            .apply_auth(self.client.get(self.url(path)))?
             .send()
             .await
-            .context("GET request failed")
+            .context("GET request failed")?;
+
+        if !res.status().is_success() {
+            let body: serde_json::Value =
+                res.json().await.context("Failed to parse response body")?;
+
+            let msg = body["error"]
+                .as_str()
+                .map(str::to_string)
+                .unwrap_or_else(|| body.to_string());
+
+            anyhow::bail!("{}", msg);
+        }
+
+        Ok(res)
     }
 
     pub async fn post<B: serde::Serialize>(
@@ -63,42 +77,44 @@ impl ApiClient {
     }
 
     pub fn url(&self, path: &str) -> String {
-        format!("{}{}", self.base_url, path)
+        format!(
+            "{}/{}",
+            self.base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
     }
 
-    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        match &self.auth_token {
-            Some(token) => req.bearer_auth(token),
-            None => req,
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> Result<reqwest::RequestBuilder> {
+        if let Some(token) = get_auth_token()? {
+            return Ok(req.bearer_auth(token));
         }
+
+        Ok(req)
     }
 
     async fn send(&self, req: reqwest::RequestBuilder) -> Result<serde_json::Value> {
         let res = self
-            .apply_auth(req)
+            .apply_auth(req)?
             .send()
             .await
             .context("Request failed")?;
-        Self::parse_response(res).await
-    }
 
-    async fn parse_response(res: reqwest::Response) -> Result<serde_json::Value> {
         let status = res.status();
         if status == reqwest::StatusCode::NO_CONTENT {
             return Ok(serde_json::Value::Null);
         }
-        let json: serde_json::Value = res.json().await.context("failed to parse response body")?;
+
+        let body: serde_json::Value = res.json().await.context("Failed to parse response body")?;
+
         if !status.is_success() {
-            let msg = json["error"]
+            let msg = body["error"]
                 .as_str()
                 .map(str::to_string)
-                .unwrap_or_else(|| json.to_string());
+                .unwrap_or_else(|| body.to_string());
+
             anyhow::bail!("{}", msg);
         }
-        Ok(json)
-    }
-}
 
-pub fn client() -> Result<ApiClient> {
-    ApiClient::from_config()
+        Ok(body)
+    }
 }

--- a/slasha-cli/src/main.rs
+++ b/slasha-cli/src/main.rs
@@ -24,6 +24,7 @@ use crate::{
     clap_app::{ClapApp, Command},
     config::Config,
     diagnostic::DiagnosticReport,
+    http::ApiClient,
     output::print_json,
     state::AppState,
 };
@@ -56,24 +57,17 @@ async fn run(cli: ClapApp) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // `serve` and `git-ssh` run inside the prod container, which has no
-    // DBus/libsecret session. Handle them before building the API client —
-    // `http::client()` reads the auth token from the OS keyring on startup,
-    // which crashes the server on a headless host.
-    let command = match command {
-        #[cfg(feature = "serve")]
-        Command::Serve => return slasha_server::start_server().await,
-        #[cfg(feature = "serve")]
-        Command::GitSsh { user_id } => return git_ssh::handle(user_id).await,
-        other => other,
-    };
-
     let state = AppState {
-        client: http::client()?.with_url_override(url),
+        api_client: ApiClient::from_config()?.with_url_override(url),
         output_mode,
     };
 
     match command {
+        #[cfg(feature = "serve")]
+        Command::Serve => slasha_server::start_server().await?,
+        #[cfg(feature = "serve")]
+        Command::GitSsh { user_id } => git_ssh::handle(user_id).await?,
+
         Command::Status => auth::handle_status(&state).await?,
         Command::Login => auth::handle_login(&state).await?,
         Command::Logout => auth::handle_logout(&state).await?,
@@ -131,9 +125,6 @@ async fn run(cli: ClapApp) -> anyhow::Result<()> {
 
         Command::SshKeys { command } => ssh_keys::dispatch(&state, command).await?,
         Command::Users { command } => users::dispatch(&state, command).await?,
-
-        #[cfg(feature = "serve")]
-        Command::Serve | Command::GitSsh { .. } => unreachable!(),
     }
 
     Ok(())

--- a/slasha-cli/src/main.rs
+++ b/slasha-cli/src/main.rs
@@ -44,23 +44,36 @@ fn resolve_app(flag: Option<String>) -> anyhow::Result<String> {
 }
 
 async fn run(cli: ClapApp) -> anyhow::Result<()> {
-    let output_mode = cli.output_mode;
-    let state = AppState {
-        client: http::client()?.with_url_override(cli.url),
+    let ClapApp {
+        command,
         output_mode,
-    };
+        url,
+        diagnostic,
+    } = cli;
 
-    if cli.diagnostic {
+    if diagnostic {
         DiagnosticReport::generate()?.print()?;
         return Ok(());
     }
 
-    match cli.command {
+    // `serve` and `git-ssh` run inside the prod container, which has no
+    // DBus/libsecret session. Handle them before building the API client —
+    // `http::client()` reads the auth token from the OS keyring on startup,
+    // which crashes the server on a headless host.
+    let command = match command {
         #[cfg(feature = "serve")]
         Command::Serve => return slasha_server::start_server().await,
         #[cfg(feature = "serve")]
         Command::GitSsh { user_id } => return git_ssh::handle(user_id).await,
+        other => other,
+    };
 
+    let state = AppState {
+        client: http::client()?.with_url_override(url),
+        output_mode,
+    };
+
+    match command {
         Command::Status => auth::handle_status(&state).await?,
         Command::Login => auth::handle_login(&state).await?,
         Command::Logout => auth::handle_logout(&state).await?,
@@ -118,6 +131,9 @@ async fn run(cli: ClapApp) -> anyhow::Result<()> {
 
         Command::SshKeys { command } => ssh_keys::dispatch(&state, command).await?,
         Command::Users { command } => users::dispatch(&state, command).await?,
+
+        #[cfg(feature = "serve")]
+        Command::Serve | Command::GitSsh { .. } => unreachable!(),
     }
 
     Ok(())

--- a/slasha-cli/src/service_env.rs
+++ b/slasha-cli/src/service_env.rs
@@ -24,7 +24,7 @@ pub async fn dispatch(
 
 pub async fn handle_list(state: &AppState, slug: &str, service_id: &str) -> Result<()> {
     let env_data = state
-        .client
+        .api_client
         .get(&format!("/api/apps/{}/services/{}/env", slug, service_id))
         .await?;
 
@@ -63,7 +63,7 @@ pub async fn handle_set(
     }
 
     let update_res = state
-        .client
+        .api_client
         .put(
             &format!("/api/apps/{}/services/{}/env", slug, service_id),
             &json!({ "vars": current }),
@@ -92,7 +92,7 @@ pub async fn handle_unset(
     }
 
     let update_res = state
-        .client
+        .api_client
         .put(
             &format!("/api/apps/{}/services/{}/env", slug, service_id),
             &json!({ "vars": current }),
@@ -112,7 +112,7 @@ async fn fetch_vars(
     service_id: &str,
 ) -> Result<HashMap<String, String>> {
     let env_data = state
-        .client
+        .api_client
         .get(&format!("/api/apps/{}/services/{}/env", slug, service_id))
         .await?;
 

--- a/slasha-cli/src/services.rs
+++ b/slasha-cli/src/services.rs
@@ -37,7 +37,7 @@ fn format_status(status: ServiceStatus) -> String {
 
 pub async fn handle_list(state: &AppState, slug: &str) -> Result<()> {
     let services_data = state
-        .client
+        .api_client
         .get(&format!("/api/apps/{}/services", slug))
         .await?;
 
@@ -78,7 +78,7 @@ pub async fn handle_create(
     let default_env = fetch_default_env(state, kind).await?;
 
     let provision_res = state
-        .client
+        .api_client
         .post(
             &format!("/api/apps/{}/services", slug),
             &json!({
@@ -120,7 +120,7 @@ pub async fn handle_stop(state: &AppState, slug: &str, service: &str, yes: bool)
     }
 
     state
-        .client
+        .api_client
         .post(
             &format!("/api/apps/{}/services/{}/stop", slug, service_id),
             &serde_json::Value::Null,
@@ -146,7 +146,7 @@ pub async fn handle_delete(state: &AppState, slug: &str, service: &str, yes: boo
     }
 
     state
-        .client
+        .api_client
         .delete(&format!("/api/apps/{}/services/{}", slug, service_id))
         .await?;
 
@@ -161,18 +161,9 @@ pub async fn handle_logs(state: &AppState, slug: &str, service: &str, follow: bo
     let service_id = resolve_service_id(state, slug, service).await?;
 
     let res = state
-        .client
+        .api_client
         .get_stream(&format!("/api/apps/{}/services/{}/logs", slug, service_id))
         .await?;
-
-    if !res.status().is_success() {
-        let body: serde_json::Value = res.json().await.context("Failed to parse response body")?;
-        let msg = body["error"]
-            .as_str()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| body.to_string());
-        anyhow::bail!("{}", msg);
-    }
 
     let mut stream = res.bytes_stream().eventsource();
 
@@ -214,7 +205,7 @@ pub async fn resolve_service_id(state: &AppState, slug: &str, name_or_id: &str) 
     }
 
     let services_data = state
-        .client
+        .api_client
         .get(&format!("/api/apps/{}/services", slug))
         .await?;
 
@@ -234,7 +225,7 @@ async fn fetch_default_env(
     state: &AppState,
     kind: &ServiceKind,
 ) -> Result<std::collections::HashMap<String, String>> {
-    let kinds_data = match state.client.get("/api/services/kinds").await {
+    let kinds_data = match state.api_client.get("/api/services/kinds").await {
         Ok(b) => b,
         Err(_) => return Ok(Default::default()),
     };

--- a/slasha-cli/src/ssh_keys.rs
+++ b/slasha-cli/src/ssh_keys.rs
@@ -21,7 +21,7 @@ pub async fn dispatch(state: &AppState, cmd: SshKeysCommand) -> Result<()> {
 }
 
 pub async fn handle_list(state: &AppState) -> Result<()> {
-    let keys_data = state.client.get("/api/ssh-keys").await?;
+    let keys_data = state.api_client.get("/api/ssh-keys").await?;
 
     let keys: Vec<SshKey> =
         serde_json::from_value(keys_data["keys"].clone()).context("Failed to parse keys")?;
@@ -71,7 +71,7 @@ pub async fn handle_add(
     let public_key = raw_key.trim().to_string();
 
     let add_res = state
-        .client
+        .api_client
         .post(
             "/api/ssh-keys",
             &json!({ "title": title, "public_key": public_key }),
@@ -92,7 +92,7 @@ pub async fn handle_add(
 
 pub async fn handle_remove(state: &AppState, id: &str) -> Result<()> {
     state
-        .client
+        .api_client
         .delete(&format!("/api/ssh-keys/{}", id))
         .await?;
 

--- a/slasha-cli/src/state.rs
+++ b/slasha-cli/src/state.rs
@@ -1,6 +1,6 @@
 use crate::{http::ApiClient, output::OutputMode};
 
 pub struct AppState {
-    pub client: ApiClient,
+    pub api_client: ApiClient,
     pub output_mode: OutputMode,
 }

--- a/slasha-cli/src/users.rs
+++ b/slasha-cli/src/users.rs
@@ -23,7 +23,7 @@ pub async fn dispatch(state: &AppState, cmd: UsersCommand) -> Result<()> {
 }
 
 pub async fn handle_list(state: &AppState) -> Result<()> {
-    let users_data = state.client.get("/api/users").await?;
+    let users_data = state.api_client.get("/api/users").await?;
 
     let users: Vec<User> =
         serde_json::from_value(users_data["users"].clone()).context("Failed to parse users")?;
@@ -55,7 +55,7 @@ pub async fn handle_create(
     role: &str,
 ) -> Result<()> {
     let create_res = state
-        .client
+        .api_client
         .post(
             "/api/users",
             &json!({
@@ -86,7 +86,7 @@ pub async fn handle_update(
     role: Option<String>,
 ) -> Result<()> {
     let update_res = state
-        .client
+        .api_client
         .put(
             &format!("/api/users/{}", id),
             &json!({
@@ -117,7 +117,10 @@ pub async fn handle_delete(state: &AppState, id: &str, yes: bool) -> Result<()> 
         return Ok(());
     }
 
-    state.client.delete(&format!("/api/users/{}", id)).await?;
+    state
+        .api_client
+        .delete(&format!("/api/users/{}", id))
+        .await?;
 
     output(state.output_mode, &json!({ "ok": true }), || {
         cli_success("User deleted.");

--- a/slasha-server/src/lib.rs
+++ b/slasha-server/src/lib.rs
@@ -106,7 +106,7 @@ pub async fn start_server() -> anyhow::Result<()> {
     let state = AppState::new(config, clients, storage, runtime);
 
     run_container_sync(
-        &state.clients.docker,
+        &state.api_clients.docker,
         &state.storage.db_pool,
         &state.runtime.log_manager,
     )

--- a/slasha-server/src/state.rs
+++ b/slasha-server/src/state.rs
@@ -123,19 +123,19 @@ impl AppState {
 
 impl FromRef<AppState> for Clients {
     fn from_ref(state: &AppState) -> Self {
-        state.clients.clone()
+        state.api_clients.clone()
     }
 }
 
 impl FromRef<AppState> for Docker {
     fn from_ref(state: &AppState) -> Self {
-        state.clients.docker.clone()
+        state.api_clients.docker.clone()
     }
 }
 
 impl FromRef<AppState> for CaddyClient {
     fn from_ref(state: &AppState) -> Self {
-        state.clients.caddy.clone()
+        state.api_clients.caddy.clone()
     }
 }
 


### PR DESCRIPTION
## Summary

`slasha serve` is in a crash-loop on prod (slasha.com is returning 502). Each restart logs only:

```
Failed to read keyring: Platform secure storage failure: DBus error: Unable to autolaunch a dbus-daemon without a $DISPLAY for X11
```

`run()` in `slasha-cli/src/main.rs` builds the API client *before* matching on the subcommand. `http::client()` (via `ApiClient::from_config` → `token::get_auth_token()`) opens a `keyring::Entry`, which on Linux talks to libsecret over DBus. The prod container has no DBus session, the call errors, the `?` propagates, and the process exits 1 — even though `serve` doesn't need the API client at all.

This was introduced when the server was bundled into the CLI binary (#2d8408d), which made the CLI's startup path execute on `slasha serve`.

## Fix

Handle `Serve` and `GitSsh` up front, before constructing `AppState`. Those subcommands never need the API client. Also moved the `--diagnostic` short-circuit above client construction since diagnostic doesn't need the client either.

## Test plan

- [x] `cargo check -p slasha-cli` (default features)
- [x] `cargo check -p slasha-cli --features serve-bundle`
- [ ] After merge: redeploy and confirm `slasha` container reaches `Up` state and `curl https://slasha.com/` returns 200

## Rollback

If anything regresses, `REF=<previous-sha> make deploy` from `slasha-infra` reverts.