### PR TITLE
feat: add MySQL, MongoDB, Redis service kinds

### DIFF
--- a/slasha-cli/src/clap_app.rs
+++ b/slasha-cli/src/clap_app.rs
@@ -124,7 +124,7 @@ pub enum Command {
 
     #[command(
         name = "provision",
-        about = "Provision a new service (e.g. PostgreSQL)"
+        about = "Provision a new service (e.g. PostgreSQL, MySQL, MongoDB, Redis)"
     )]
     Provision {
         #[arg(long, value_name = "SLUG")]

--- a/slasha-db/src/models/service.rs
+++ b/slasha-db/src/models/service.rs
@@ -48,24 +48,36 @@ pub struct Service {
 #[ts(export, export_to = "./service.ts")]
 pub enum ServiceKind {
     PostgreSQL,
+    MySQL,
+    MongoDB,
+    Redis,
 }
 
 impl ServiceKind {
     pub fn docker_image(&self, version: &str) -> String {
         match self {
             ServiceKind::PostgreSQL => format!("postgres:{}", version),
+            ServiceKind::MySQL => format!("mysql:{}", version),
+            ServiceKind::MongoDB => format!("mongo:{}", version),
+            ServiceKind::Redis => format!("redis:{}", version),
         }
     }
 
     pub fn container_port(&self) -> u16 {
         match self {
             ServiceKind::PostgreSQL => 5432,
+            ServiceKind::MySQL => 3306,
+            ServiceKind::MongoDB => 27017,
+            ServiceKind::Redis => 6379,
         }
     }
 
     pub fn supported_versions(&self) -> Vec<&str> {
         match self {
             ServiceKind::PostgreSQL => vec!["17", "16", "15", "14", "13"],
+            ServiceKind::MySQL => vec!["9.0", "8.4", "8.0"],
+            ServiceKind::MongoDB => vec!["8.0", "7.0", "6.0"],
+            ServiceKind::Redis => vec!["7.4", "7.2", "7.0"],
         }
     }
 
@@ -81,12 +93,43 @@ impl ServiceKind {
                     "postgres://${{ POSTGRES_USER }}:${{ POSTGRES_PASSWORD }}@${{ SLASHA.service_container_name }}:${{ PORT }}/${{ POSTGRES_DB }}".to_string(),
                 ),
             ]),
+            ServiceKind::MySQL => HashMap::from([
+                ("MYSQL_ROOT_PASSWORD".to_string(), "mysql".to_string()),
+                ("MYSQL_USER".to_string(), "mysql".to_string()),
+                ("MYSQL_PASSWORD".to_string(), "mysql".to_string()),
+                ("MYSQL_DATABASE".to_string(), "mysql".to_string()),
+                ("PORT".to_string(), "3306".to_string()),
+                (
+                    "DATABASE_URL".to_string(),
+                    "mysql://${{ MYSQL_USER }}:${{ MYSQL_PASSWORD }}@${{ SLASHA.service_container_name }}:${{ PORT }}/${{ MYSQL_DATABASE }}".to_string(),
+                ),
+            ]),
+            ServiceKind::MongoDB => HashMap::from([
+                ("MONGO_INITDB_ROOT_USERNAME".to_string(), "mongo".to_string()),
+                ("MONGO_INITDB_ROOT_PASSWORD".to_string(), "mongo".to_string()),
+                ("MONGO_INITDB_DATABASE".to_string(), "mongo".to_string()),
+                ("PORT".to_string(), "27017".to_string()),
+                (
+                    "DATABASE_URL".to_string(),
+                    "mongodb://${{ MONGO_INITDB_ROOT_USERNAME }}:${{ MONGO_INITDB_ROOT_PASSWORD }}@${{ SLASHA.service_container_name }}:${{ PORT }}/${{ MONGO_INITDB_DATABASE }}?authSource=admin".to_string(),
+                ),
+            ]),
+            ServiceKind::Redis => HashMap::from([
+                ("PORT".to_string(), "6379".to_string()),
+                (
+                    "DATABASE_URL".to_string(),
+                    "redis://${{ SLASHA.service_container_name }}:${{ PORT }}".to_string(),
+                ),
+            ]),
         }
     }
 
     pub fn volume_mount_path(&self) -> &'static str {
         match self {
             ServiceKind::PostgreSQL => "/var/lib/postgresql/data",
+            ServiceKind::MySQL => "/var/lib/mysql",
+            ServiceKind::MongoDB => "/data/db",
+            ServiceKind::Redis => "/data",
         }
     }
 }

--- a/web/app/models/service.ts
+++ b/web/app/models/service.ts
@@ -20,6 +20,6 @@ export type ServiceEnvVar = {
   updated_at: string;
 };
 
-export type ServiceKind = 'PostgreSQL';
+export type ServiceKind = 'PostgreSQL' | 'MySQL' | 'MongoDB' | 'Redis';
 
 export type ServiceStatus = 'Provisioning' | 'Running' | 'Stopped' | 'Failed';


### PR DESCRIPTION
## Summary
- Extended `ServiceKind` in slasha-db with `MySQL`, `MongoDB`, and `Redis`, each wired through `docker_image`, `container_port`, `supported_versions`, `default_env_vars`, and `volume_mount_path`.
- Updated the generated `ServiceKind` union in `web/app/models/service.ts` so the provision modal renders all four kinds.
- Refreshed the `slasha provision` CLI help text.

The `services.kind` column is plain text, so no migration is needed. The CLI picks up the new variants via `ServiceKind::VARIANTS` and the web UI populates kinds/versions from `/api/services/kinds`.

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] Provision a MySQL service and verify the container starts, env vars resolve, and `DATABASE_URL` is reachable from a deployed app
- [ ] Provision a MongoDB service and verify root credentials apply on first boot
- [ ] Provision a Redis service and verify the consumer app can connect via `DATABASE_URL`
- [ ] Existing PostgreSQL provisioning still works unchanged