### PR TITLE
feat: secure WebSocket tunnel for service access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -212,8 +213,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -739,6 +742,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbus"
@@ -3272,7 +3281,9 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -3665,6 +3676,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3920,6 +3947,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3980,7 +4026,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4237,6 +4283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/slasha-cli/Cargo.toml
+++ b/slasha-cli/Cargo.toml
@@ -24,6 +24,8 @@ indicatif = "0.18.4"
 inquire = "0.9.4"
 reqwest = { version = "0.13.2", features = ["json", "stream"] }
 eventsource-stream = "0.2.3"
+tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
+url = "2.5"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 slasha-db = { path = "../slasha-db" }

--- a/slasha-cli/src/clap_app.rs
+++ b/slasha-cli/src/clap_app.rs
@@ -131,8 +131,6 @@ pub enum Command {
         name: String,
         #[arg(long)]
         version: String,
-        #[arg(long)]
-        expose: bool,
     },
 
     #[command(name = "services", about = "Manage attached services")]
@@ -141,6 +139,21 @@ pub enum Command {
         app: Option<String>,
         #[command(subcommand)]
         command: ServicesCommand,
+    },
+
+    #[command(
+        name = "proxy",
+        about = "Tunnel a remote service to a local TCP port over HTTPS"
+    )]
+    Proxy {
+        #[arg(long, value_name = "SLUG")]
+        app: Option<String>,
+        #[arg(value_name = "NAME_OR_ID")]
+        service: String,
+        #[arg(short = 'p', long, value_name = "PORT")]
+        port: Option<u16>,
+        #[arg(long, help = "Mask passwords in printed connection string")]
+        no_secret: bool,
     },
 
     #[command(name = "env", about = "Manage app env vars")]

--- a/slasha-cli/src/main.rs
+++ b/slasha-cli/src/main.rs
@@ -10,6 +10,7 @@ mod domains;
 mod git_ssh;
 mod http;
 mod output;
+mod proxy;
 mod scale;
 mod service_env;
 mod services;
@@ -123,11 +124,7 @@ async fn run(cli: ClapApp) -> anyhow::Result<i32> {
             kind,
             name,
             version,
-            expose,
-        } => {
-            services::handle_create(&state, &resolve_app(app)?, &kind, &name, &version, expose)
-                .await?
-        }
+        } => services::handle_create(&state, &resolve_app(app)?, &kind, &name, &version).await?,
 
         Command::AppEnv { app, command } => {
             app_env::dispatch(&state, &resolve_app(app)?, command).await?
@@ -136,6 +133,13 @@ async fn run(cli: ClapApp) -> anyhow::Result<i32> {
         Command::Services { app, command } => {
             services::dispatch(&state, &resolve_app(app)?, command).await?
         }
+
+        Command::Proxy {
+            app,
+            service,
+            port,
+            no_secret,
+        } => proxy::handle_proxy(&state, &resolve_app(app)?, &service, port, no_secret).await?,
 
         Command::Scale { app, pairs } => {
             scale::handle_scale(&state, &resolve_app(app)?, pairs).await?

--- a/slasha-cli/src/proxy.rs
+++ b/slasha-cli/src/proxy.rs
@@ -1,0 +1,248 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, anyhow};
+use colored::Colorize;
+use futures_util::{SinkExt, StreamExt};
+use slasha_db::service::{Service, ServiceKind};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{Bytes, Message, client::IntoClientRequest, http::HeaderValue},
+};
+
+use crate::{
+    output::{cli_error, cli_info, cli_label, cli_success},
+    state::AppState,
+    token::get_auth_token,
+};
+
+const WS_CONNECT_TIMEOUT_SECS: u64 = 15;
+const BIND_HOST: &str = "127.0.0.1";
+
+pub async fn handle_proxy(
+    state: &AppState,
+    slug: &str,
+    service: &str,
+    port: Option<u16>,
+    no_secret: bool,
+) -> Result<()> {
+    let resolved = resolve_service(state, slug, service).await?;
+    let env_vars = fetch_service_env(state, slug, &resolved.id).await?;
+
+    let listener = TcpListener::bind((BIND_HOST, port.unwrap_or(0)))
+        .await
+        .with_context(|| format!("Failed to bind {}:{}", BIND_HOST, port.unwrap_or(0)))?;
+    let local_addr = listener.local_addr()?;
+
+    let ws_url = build_ws_url(state.api_client.base_url(), slug, &resolved.id)?;
+    let token = get_auth_token()?.ok_or_else(|| anyhow!("Not authenticated. Run `slasha login`."))?;
+
+    print_banner(&resolved, &env_vars, BIND_HOST, local_addr.port(), no_secret);
+
+    loop {
+        let (socket, peer) = listener.accept().await?;
+        let ws_url = ws_url.clone();
+        let token = token.clone();
+        let service_name = resolved.name.clone();
+
+        tokio::spawn(async move {
+            cli_info(format!("→ {} accepted from {}", service_name, peer));
+            if let Err(e) = forward_connection(socket, &ws_url, &token).await {
+                cli_error(format!("tunnel connection error: {}", e));
+            }
+        });
+    }
+}
+
+struct ResolvedService {
+    id: String,
+    name: String,
+    kind: ServiceKind,
+}
+
+async fn resolve_service(state: &AppState, slug: &str, name_or_id: &str) -> Result<ResolvedService> {
+    let body = state
+        .api_client
+        .get(&format!("/api/apps/{}/services", slug))
+        .await?;
+
+    let services: Vec<Service> = serde_json::from_value(body["services"].clone())
+        .context("Failed to parse services")?;
+
+    for svc in services {
+        if svc.name == name_or_id || svc.id == name_or_id {
+            return Ok(ResolvedService {
+                id: svc.id,
+                name: svc.name,
+                kind: svc.kind,
+            });
+        }
+    }
+
+    anyhow::bail!("Service '{}' not found", name_or_id)
+}
+
+async fn fetch_service_env(
+    state: &AppState,
+    slug: &str,
+    service_id: &str,
+) -> Result<HashMap<String, String>> {
+    let body = state
+        .api_client
+        .get(&format!("/api/apps/{}/services/{}/env", slug, service_id))
+        .await?;
+
+    serde_json::from_value(body["env_vars"].clone())
+        .context("Failed to parse service env vars")
+}
+
+fn build_ws_url(base_url: &str, slug: &str, service_id: &str) -> Result<String> {
+    let url = url::Url::parse(base_url).with_context(|| format!("Invalid base URL: {}", base_url))?;
+    let ws_scheme = match url.scheme() {
+        "https" => "wss",
+        "http" => "ws",
+        other => anyhow::bail!("Unsupported base URL scheme: {}", other),
+    };
+
+    let host = url.host_str().ok_or_else(|| anyhow!("Base URL has no host"))?;
+    let mut origin = format!("{}://{}", ws_scheme, host);
+    if let Some(p) = url.port() {
+        origin.push_str(&format!(":{}", p));
+    }
+
+    Ok(format!(
+        "{}/api/apps/{}/services/{}/tunnel",
+        origin, slug, service_id
+    ))
+}
+
+async fn forward_connection(
+    mut tcp: tokio::net::TcpStream,
+    ws_url: &str,
+    token: &str,
+) -> Result<()> {
+    let mut request = ws_url
+        .into_client_request()
+        .context("Failed to build WebSocket request")?;
+    request.headers_mut().insert(
+        "Authorization",
+        HeaderValue::from_str(&format!("Bearer {}", token))?,
+    );
+
+    let (ws_stream, _resp) = tokio::time::timeout(
+        std::time::Duration::from_secs(WS_CONNECT_TIMEOUT_SECS),
+        connect_async(request),
+    )
+    .await
+    .context("WebSocket upgrade timed out")?
+    .context("WebSocket upgrade failed")?;
+
+    let (mut ws_tx, mut ws_rx) = ws_stream.split();
+    let (mut tcp_rd, mut tcp_wr) = tcp.split();
+
+    let ws_to_tcp = async {
+        while let Some(msg) = ws_rx.next().await {
+            match msg? {
+                Message::Binary(bytes) => tcp_wr.write_all(&bytes).await?,
+                Message::Close(_) => break,
+                Message::Ping(_) | Message::Pong(_) => {}
+                Message::Text(_) | Message::Frame(_) => {}
+            }
+        }
+        tcp_wr.shutdown().await.ok();
+        Ok::<(), anyhow::Error>(())
+    };
+
+    let tcp_to_ws = async {
+        let mut buf = vec![0u8; 16 * 1024];
+        loop {
+            let n = tcp_rd.read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            ws_tx
+                .send(Message::Binary(Bytes::copy_from_slice(&buf[..n])))
+                .await?;
+        }
+        ws_tx.send(Message::Close(None)).await.ok();
+        Ok::<(), anyhow::Error>(())
+    };
+
+    tokio::select! {
+        r = ws_to_tcp => r,
+        r = tcp_to_ws => r,
+    }
+}
+
+fn print_banner(
+    service: &ResolvedService,
+    env_vars: &HashMap<String, String>,
+    bind: &str,
+    port: u16,
+    no_secret: bool,
+) {
+    cli_success(format!(
+        "Tunneling {} ({})",
+        service.name.cyan(),
+        service.kind.to_string().dimmed()
+    ));
+    cli_label("Listening on", format!("{}:{}", bind, port));
+
+    let dsn = build_dsn(service.kind, env_vars, bind, port, no_secret);
+    cli_label("Connection string", dsn);
+    cli_info("Each new client opens an independent tunnel. Press Ctrl-C to stop.");
+}
+
+fn build_dsn(
+    kind: ServiceKind,
+    env: &HashMap<String, String>,
+    host: &str,
+    port: u16,
+    no_secret: bool,
+) -> String {
+    let mask = |k: &str| -> String {
+        if no_secret {
+            "<password>".to_string()
+        } else {
+            env.get(k).cloned().unwrap_or_default()
+        }
+    };
+    let get = |k: &str| env.get(k).cloned().unwrap_or_default();
+
+    match kind {
+        ServiceKind::PostgreSQL => format!(
+            "postgresql://{}:{}@{}:{}/{}",
+            get("POSTGRES_USER"),
+            mask("POSTGRES_PASSWORD"),
+            host,
+            port,
+            get("POSTGRES_DB"),
+        ),
+        ServiceKind::MySQL => format!(
+            "mysql://{}:{}@{}:{}/{}",
+            get("MYSQL_USER"),
+            mask("MYSQL_PASSWORD"),
+            host,
+            port,
+            get("MYSQL_DATABASE"),
+        ),
+        ServiceKind::MongoDB => format!(
+            "mongodb://{}:{}@{}:{}/{}?authSource=admin",
+            get("MONGO_INITDB_ROOT_USERNAME"),
+            mask("MONGO_INITDB_ROOT_PASSWORD"),
+            host,
+            port,
+            get("MONGO_INITDB_DATABASE"),
+        ),
+        ServiceKind::Redis => format!(
+            "redis://default:{}@{}:{}",
+            mask("REDIS_PASSWORD"),
+            host,
+            port,
+        ),
+    }
+}
+

--- a/slasha-cli/src/services.rs
+++ b/slasha-cli/src/services.rs
@@ -76,7 +76,6 @@ pub async fn handle_create(
     kind: &ServiceKind,
     name: &str,
     version: &str,
-    expose: bool,
 ) -> Result<()> {
     let default_env = fetch_default_env(state, kind).await?;
 
@@ -89,7 +88,6 @@ pub async fn handle_create(
                 "name": name,
                 "version": version,
                 "env_vars": default_env,
-                "exposed": expose,
             }),
         )
         .await?;
@@ -103,9 +101,12 @@ pub async fn handle_create(
         cli_label("Name", &svc.name);
         cli_label("Kind", svc.kind);
         cli_label("Version", &svc.version);
-        cli_label("Exposed", if expose { "Yes" } else { "No" });
         cli_info(format!(
-            "\nFollow service logs: slasha services logs --app {} --service {} --follow",
+            "\nFollow service logs: slasha services logs {} --follow",
+            svc.name
+        ));
+        cli_info(format!(
+            "Connect locally:    slasha proxy --app {} {}",
             slug, svc.name
         ));
     })?;

--- a/slasha-server/Cargo.toml
+++ b/slasha-server/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.102"
-axum = "0.8.8"
+axum = { version = "0.8.8", features = ["ws"] }
 axum-extra = { version = "0.12.5", features = ["cookie", "typed-header"] }
 diesel = { version = "2.2.0", features = ["sqlite", "returning_clauses_for_sqlite_3_35", "r2d2", "chrono"] }
 mime_guess = { version = "2.0.5", optional = true }
@@ -32,7 +32,7 @@ flate2 = "1.1.9"
 tokio-util = { version = "0.7.18", features = ["io"] }
 git2 = "0.20.4"
 bollard = { version = "0.20.2", features = ["buildkit", "chrono"] }
-futures-util = "0.3.32"
+futures-util = { version = "0.3.32", features = ["sink"] }
 dashmap = "6.1.0"
 bytes = "1"
 file-rotate = "0.8.0"

--- a/slasha-server/src/docker/service/provision.rs
+++ b/slasha-server/src/docker/service/provision.rs
@@ -8,7 +8,7 @@ use bollard::{
     Docker,
     models::{
         EndpointSettings, HealthConfig, HealthStatusEnum, HostConfig, Mount, MountTypeEnum,
-        NetworkingConfig, PortBinding, ProgressDetail, RestartPolicy, RestartPolicyNameEnum,
+        NetworkingConfig, ProgressDetail, RestartPolicy, RestartPolicyNameEnum,
         VolumeCreateRequest,
     },
     query_parameters::{
@@ -73,7 +73,6 @@ pub async fn provision_service(
     app: App,
     service: Service,
     initial_env: Option<HashMap<String, String>>,
-    exposed: bool,
 ) -> DeploymentResult<()> {
     let log_key = LogKey::Service {
         app_slug: app.slug.clone(),
@@ -88,7 +87,6 @@ pub async fn provision_service(
         &app,
         &service,
         initial_env,
-        exposed,
         &log,
         &mut rollback,
     )
@@ -112,7 +110,6 @@ async fn provision_inner(
     app: &App,
     service: &Service,
     initial_env: Option<HashMap<String, String>>,
-    exposed: bool,
     log: &Log,
     rollback: &mut Rollback,
 ) -> DeploymentResult<()> {
@@ -177,7 +174,7 @@ async fn provision_inner(
 
     let resolved_vars = resolve_env_vars(env_vars, service)?;
 
-    create_service_container(docker, service, app, &resolved_vars, exposed, rollback).await?;
+    create_service_container(docker, service, app, &resolved_vars, rollback).await?;
     start_and_wait_healthy(docker, service, log).await?;
     ServiceRepo::update_status(db_pool, &service.id, ServiceStatus::Running).await?;
     Ok(())
@@ -188,7 +185,6 @@ async fn create_service_container(
     service: &Service,
     app: &App,
     resolved_env: &HashMap<String, String>,
-    exposed: bool,
     rollback: &mut Rollback,
 ) -> DeploymentResult<()> {
     let image_name = service.kind.docker_image(&service.version);
@@ -215,22 +211,6 @@ async fn create_service_container(
         .map(|(k, v)| format!("{}={}", k, v))
         .collect();
     let overrides = service.resources.clone().unwrap_or_default();
-
-    let port_bindings = if exposed {
-        let mut bindings = HashMap::new();
-        // `host_port: None` tells Docker to pick a random ephemeral port.
-        // The actual port is read back via `inspect_container` in the API layer.
-        bindings.insert(
-            format!("{}/tcp", service.kind.container_port()),
-            Some(vec![PortBinding {
-                host_ip: None,
-                host_port: None,
-            }]),
-        );
-        Some(bindings)
-    } else {
-        None
-    };
 
     docker_client
         .create_container(
@@ -287,7 +267,6 @@ async fn create_service_container(
                             .shm_size
                             .unwrap_or_else(|| service.kind.default_shm_size()),
                     ),
-                    port_bindings,
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/slasha-server/src/lib.rs
+++ b/slasha-server/src/lib.rs
@@ -9,6 +9,7 @@ pub mod proxy;
 pub mod routing;
 pub mod ssh;
 pub mod state;
+pub mod tunnel;
 pub mod utils;
 
 use std::net::SocketAddr;

--- a/slasha-server/src/routing/api/apps/services.rs
+++ b/slasha-server/src/routing/api/apps/services.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use axum::{
     Json, Router,
-    extract::{Path, State},
+    extract::{Path, State, WebSocketUpgrade},
     response::{
         IntoResponse,
         sse::{Event, KeepAlive, Sse},
@@ -16,7 +16,7 @@ use serde::Deserialize;
 use slasha_db::{
     DbPool,
     repos::{app::AppRepo, service::ServiceRepo},
-    service::{Service, ServiceKind, ServiceResources, ServiceStatus},
+    service::{ServiceKind, ServiceResources, ServiceStatus},
 };
 use tokio::sync::Notify;
 use tokio_stream::wrappers::BroadcastStream;
@@ -31,6 +31,7 @@ use crate::{
     error::{HttpError, HttpResult},
     extractors::auth::AuthUser,
     state::AppState,
+    tunnel,
 };
 
 pub fn router() -> Router<AppState> {
@@ -38,11 +39,10 @@ pub fn router() -> Router<AppState> {
         .route("/", get(list_services))
         .route("/", post(create_service))
         .route("/{id}/logs", get(stream_logs))
+        .route("/{id}/tunnel", get(tunnel_handler))
         .route("/{id}/restart", post(restart_service_handler))
         .route("/{id}/redeploy", post(redeploy_service_handler))
         .route("/{id}/stop", post(stop_service_handler))
-        .route("/{id}/expose", post(expose_service_handler))
-        .route("/{id}/expose", delete(unexpose_service_handler))
         .route("/{id}", delete(delete_service_handler))
 }
 
@@ -53,73 +53,19 @@ struct CreateServiceReq {
     version: String,
     env_vars: HashMap<String, String>,
     #[serde(default)]
-    exposed: bool,
-    #[serde(default)]
     resources: Option<ServiceResources>,
 }
 
-#[derive(serde::Serialize)]
-struct ServiceExposure {
-    host_port: u16,
-    bind_addr: String,
-}
-
-#[derive(serde::Serialize)]
-struct ServiceWithExposure {
-    #[serde(flatten)]
-    service: Service,
-    exposure: Option<ServiceExposure>,
-}
-
-async fn read_service_exposure(
-    docker: &Docker,
-    service_id: &str,
-    container_port: u16,
-) -> Option<ServiceExposure> {
-    let container_name = service_container_name(service_id);
-    let info = docker.inspect_container(&container_name, None).await.ok()?;
-
-    let bindings = info.network_settings?.ports?;
-    let key = format!("{}/tcp", container_port);
-    let binding = bindings.get(&key)?.as_ref()?.first()?;
-
-    let host_port = binding.host_port.as_ref()?.parse::<u16>().ok()?;
-    let bind_addr = binding
-        .host_ip
-        .clone()
-        .filter(|ip| !ip.is_empty() && ip != "0.0.0.0")
-        .unwrap_or_else(|| "127.0.0.1".to_string()); // Default to localhost for display if 0.0.0.0
-
-    Some(ServiceExposure {
-        host_port,
-        bind_addr,
-    })
-}
-
 async fn list_services(
-    State(docker): State<Docker>,
     State(db_pool): State<DbPool>,
     AuthUser(user): AuthUser,
     Path(slug): Path<String>,
 ) -> HttpResult<impl IntoResponse> {
     let app = AppRepo::find_by_slug_for_user(&db_pool, &slug, &user.id).await?;
-    let app_services = ServiceRepo::list_for_app(&db_pool, &app.id).await?;
-
-    let mut enriched = Vec::with_capacity(app_services.len());
-    for svc in app_services {
-        let exposure = if svc.status == ServiceStatus::Running {
-            read_service_exposure(&docker, &svc.id, svc.kind.container_port()).await
-        } else {
-            None
-        };
-        enriched.push(ServiceWithExposure {
-            service: svc,
-            exposure,
-        });
-    }
+    let services = ServiceRepo::list_for_app(&db_pool, &app.id).await?;
 
     Ok(Json(serde_json::json!({
-        "services": enriched,
+        "services": services,
     })))
 }
 
@@ -163,7 +109,7 @@ async fn create_service(
     let now = Utc::now().naive_utc();
     let service_id = Uuid::new_v4().to_string();
 
-    let new_service = Service {
+    let new_service = slasha_db::service::Service {
         id: service_id.clone(),
         app_id: app.id.clone(),
         kind: payload.kind,
@@ -184,7 +130,6 @@ async fn create_service(
         app,
         new_service.clone(),
         Some(payload.env_vars),
-        payload.exposed,
     ));
 
     Ok(Json(serde_json::json!({
@@ -192,73 +137,24 @@ async fn create_service(
     })))
 }
 
-async fn expose_service_handler(
+async fn tunnel_handler(
+    ws: WebSocketUpgrade,
     State(docker): State<Docker>,
     State(db_pool): State<DbPool>,
-    State(log_manager): State<Arc<LogManager>>,
     AuthUser(user): AuthUser,
     Path((slug, id)): Path<(String, String)>,
 ) -> HttpResult<impl IntoResponse> {
     let app = AppRepo::find_by_slug_for_user(&db_pool, &slug, &user.id).await?;
     let svc = ServiceRepo::find(&db_pool, &id, &app.id).await?;
 
-    let container_name = service_container_name(&svc.id);
-    let _ = docker
-        .remove_container(
-            &container_name,
-            Some(
-                bollard::query_parameters::RemoveContainerOptionsBuilder::new()
-                    .force(true)
-                    .build(),
-            ),
-        )
-        .await;
+    if svc.status != ServiceStatus::Running {
+        return Err(HttpError::bad_request("Service is not running"));
+    }
 
-    ServiceRepo::update_status(&db_pool, &svc.id, ServiceStatus::Provisioning).await?;
-
-    tokio::spawn(provision_service(
-        docker,
-        db_pool,
-        log_manager,
-        app,
-        svc,
-        None,
-        true,
-    ));
-
-    Ok(Json(serde_json::json!({ "exposing": true })))
-}
-
-async fn unexpose_service_handler(
-    State(docker): State<Docker>,
-    State(db_pool): State<DbPool>,
-    State(log_manager): State<Arc<LogManager>>,
-    AuthUser(user): AuthUser,
-    Path((slug, id)): Path<(String, String)>,
-) -> HttpResult<impl IntoResponse> {
-    let app = AppRepo::find_by_slug_for_user(&db_pool, &slug, &user.id).await?;
-    let svc = ServiceRepo::find(&db_pool, &id, &app.id).await?;
-
-    let container_name = service_container_name(&svc.id);
-    let _ = docker
-        .remove_container(
-            &container_name,
-            Some(
-                bollard::query_parameters::RemoveContainerOptionsBuilder::new()
-                    .force(true)
-                    .build(),
-            ),
-        )
-        .await;
-
-    // Reset to Provisioning so startup_container_sync can clean up orphans on crash
-    ServiceRepo::update_status(&db_pool, &svc.id, ServiceStatus::Provisioning).await?;
-
-    tokio::spawn(async move {
-        let _ = provision_service(docker, db_pool, log_manager, app, svc, None, false).await;
-    });
-
-    Ok(Json(serde_json::json!({ "unexposing": true })))
+    let user_id = user.id.clone();
+    Ok(ws.on_upgrade(move |socket| async move {
+        tunnel::handle_tunnel(socket, docker, svc, user_id).await;
+    }))
 }
 
 async fn restart_service_handler(
@@ -295,10 +191,6 @@ async fn redeploy_service_handler(
     let app = AppRepo::find_by_slug_for_user(&db_pool, &slug, &user.id).await?;
     let svc = ServiceRepo::find(&db_pool, &id, &app.id).await?;
 
-    let exposed = read_service_exposure(&docker, &svc.id, svc.kind.container_port())
-        .await
-        .is_some();
-
     let container_name = service_container_name(&svc.id);
     let _ = docker
         .remove_container(
@@ -325,7 +217,6 @@ async fn redeploy_service_handler(
         app,
         svc,
         None,
-        exposed,
     ));
 
     Ok(Json(serde_json::json!({ "redeploying": true })))

--- a/slasha-server/src/tunnel/mod.rs
+++ b/slasha-server/src/tunnel/mod.rs
@@ -1,0 +1,313 @@
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use axum::extract::ws::{Message, WebSocket};
+use bollard::Docker;
+use bytes::Bytes;
+use dashmap::DashMap;
+use futures_util::{SinkExt, StreamExt};
+use once_cell::sync::Lazy;
+use slasha_db::service::Service;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    sync::Mutex,
+    time::interval,
+};
+
+use crate::docker::naming::{app_network_name, service_container_name};
+
+const MAX_TUNNELS_PER_USER: usize = 10;
+const IDLE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const PING_INTERVAL: Duration = Duration::from_secs(20);
+const TCP_READ_BUFFER: usize = 16 * 1024;
+
+static USER_TUNNEL_COUNTS: Lazy<DashMap<String, usize>> = Lazy::new(DashMap::new);
+
+#[derive(Debug, thiserror::Error)]
+pub enum TunnelError {
+    #[error("service container is not running")]
+    NotRunning,
+    #[error("service container has no IP on app network")]
+    NoNetworkAddress,
+    #[error("tunnel limit reached ({0} concurrent tunnels per user)")]
+    LimitReached(usize),
+    #[error("docker error: {0}")]
+    Docker(#[from] bollard::errors::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+struct TunnelGuard {
+    user_id: String,
+}
+
+impl TunnelGuard {
+    fn try_acquire(user_id: &str) -> Result<Self, TunnelError> {
+        let mut entry = USER_TUNNEL_COUNTS
+            .entry(user_id.to_string())
+            .or_insert(0);
+        if *entry >= MAX_TUNNELS_PER_USER {
+            return Err(TunnelError::LimitReached(MAX_TUNNELS_PER_USER));
+        }
+        *entry += 1;
+        Ok(Self {
+            user_id: user_id.to_string(),
+        })
+    }
+}
+
+impl Drop for TunnelGuard {
+    fn drop(&mut self) {
+        if let Some(mut entry) = USER_TUNNEL_COUNTS.get_mut(&self.user_id) {
+            *entry = entry.saturating_sub(1);
+        }
+    }
+}
+
+async fn resolve_upstream(
+    docker: &Docker,
+    service: &Service,
+) -> Result<(String, u16), TunnelError> {
+    let container_name = service_container_name(&service.id);
+    let info = docker.inspect_container(&container_name, None).await?;
+
+    let running = info
+        .state
+        .as_ref()
+        .and_then(|s| s.running)
+        .unwrap_or(false);
+    if !running {
+        return Err(TunnelError::NotRunning);
+    }
+
+    let network_name = app_network_name(&service.app_id);
+    let ip = info
+        .network_settings
+        .and_then(|s| s.networks)
+        .and_then(|nets| nets.get(&network_name).cloned())
+        .and_then(|n| n.ip_address)
+        .filter(|s| !s.is_empty())
+        .ok_or(TunnelError::NoNetworkAddress)?;
+
+    Ok((ip, service.kind.container_port()))
+}
+
+pub async fn handle_tunnel(
+    socket: WebSocket,
+    docker: Docker,
+    service: Service,
+    user_id: String,
+) {
+    let guard = match TunnelGuard::try_acquire(&user_id) {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::warn!(
+                user_id = %user_id,
+                service_id = %service.id,
+                "tunnel rejected: {}",
+                e
+            );
+            close_with_reason(socket, &e.to_string()).await;
+            return;
+        }
+    };
+
+    let (ip, port) = match resolve_upstream(&docker, &service).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                user_id = %user_id,
+                service_id = %service.id,
+                "tunnel upstream resolution failed: {}",
+                e
+            );
+            close_with_reason(socket, &e.to_string()).await;
+            return;
+        }
+    };
+
+    let tcp = match TcpStream::connect((ip.as_str(), port)).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                user_id = %user_id,
+                service_id = %service.id,
+                upstream = %format!("{}:{}", ip, port),
+                "tunnel upstream connect failed: {}",
+                e
+            );
+            close_with_reason(socket, &format!("upstream connect failed: {}", e)).await;
+            return;
+        }
+    };
+
+    tracing::info!(
+        user_id = %user_id,
+        app_id = %service.app_id,
+        service_id = %service.id,
+        upstream = %format!("{}:{}", ip, port),
+        "tunnel opened"
+    );
+
+    let started_at = Instant::now();
+    let result = forward(socket, tcp).await;
+    let elapsed = started_at.elapsed();
+
+    match result {
+        Ok((up, down)) => tracing::info!(
+            user_id = %user_id,
+            service_id = %service.id,
+            duration_ms = elapsed.as_millis() as u64,
+            bytes_up = up,
+            bytes_down = down,
+            "tunnel closed"
+        ),
+        Err(e) => tracing::warn!(
+            user_id = %user_id,
+            service_id = %service.id,
+            duration_ms = elapsed.as_millis() as u64,
+            "tunnel closed with error: {}",
+            e
+        ),
+    }
+
+    drop(guard);
+}
+
+async fn close_with_reason(socket: WebSocket, reason: &str) {
+    let (mut tx, _) = socket.split();
+    let _ = tx
+        .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+            code: 1011,
+            reason: reason.to_string().into(),
+        })))
+        .await;
+}
+
+async fn forward(socket: WebSocket, tcp: TcpStream) -> std::io::Result<(u64, u64)> {
+    let (ws_tx, ws_rx) = socket.split();
+    let (tcp_rd, tcp_wr) = tcp.into_split();
+
+    let ws_tx = Arc::new(Mutex::new(ws_tx));
+    let last_activity = Arc::new(Mutex::new(Instant::now()));
+
+    let bytes_up = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let bytes_down = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+    let ws_to_tcp = tokio::spawn(pump_ws_to_tcp(
+        ws_rx,
+        tcp_wr,
+        last_activity.clone(),
+        bytes_up.clone(),
+    ));
+    let tcp_to_ws = tokio::spawn(pump_tcp_to_ws(
+        tcp_rd,
+        ws_tx.clone(),
+        last_activity.clone(),
+        bytes_down.clone(),
+    ));
+    let keepalive = tokio::spawn(keepalive_loop(ws_tx.clone(), last_activity.clone()));
+
+    let result = tokio::select! {
+        r = ws_to_tcp => r.unwrap_or(Ok(())),
+        r = tcp_to_ws => r.unwrap_or(Ok(())),
+        r = keepalive => r.unwrap_or(Ok(())),
+    };
+
+    // ensure background tasks unwind even if one direction is still active
+    let mut tx = ws_tx.lock().await;
+    let _ = tx.close().await;
+
+    result.map(|_| {
+        (
+            bytes_up.load(std::sync::atomic::Ordering::Relaxed),
+            bytes_down.load(std::sync::atomic::Ordering::Relaxed),
+        )
+    })
+}
+
+async fn pump_ws_to_tcp(
+    mut ws_rx: futures_util::stream::SplitStream<WebSocket>,
+    mut tcp_wr: tokio::net::tcp::OwnedWriteHalf,
+    last_activity: Arc<Mutex<Instant>>,
+    bytes_up: Arc<std::sync::atomic::AtomicU64>,
+) -> std::io::Result<()> {
+    while let Some(msg) = ws_rx.next().await {
+        let msg = msg.map_err(io_other)?;
+        match msg {
+            Message::Binary(bytes) => {
+                tcp_wr.write_all(&bytes).await?;
+                bytes_up.fetch_add(bytes.len() as u64, std::sync::atomic::Ordering::Relaxed);
+                *last_activity.lock().await = Instant::now();
+            }
+            Message::Close(_) => break,
+            Message::Ping(_) | Message::Pong(_) => {}
+            Message::Text(_) => {
+                // protocol violation — client should send Binary frames
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "text frames not supported on tunnel",
+                ));
+            }
+        }
+    }
+    tcp_wr.shutdown().await?;
+    Ok(())
+}
+
+async fn pump_tcp_to_ws(
+    mut tcp_rd: tokio::net::tcp::OwnedReadHalf,
+    ws_tx: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    last_activity: Arc<Mutex<Instant>>,
+    bytes_down: Arc<std::sync::atomic::AtomicU64>,
+) -> std::io::Result<()> {
+    let mut buf = vec![0u8; TCP_READ_BUFFER];
+    loop {
+        let n = tcp_rd.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        let chunk = Bytes::copy_from_slice(&buf[..n]);
+        let len = chunk.len() as u64;
+        {
+            let mut tx = ws_tx.lock().await;
+            tx.send(Message::Binary(chunk)).await.map_err(io_other)?;
+        }
+        bytes_down.fetch_add(len, std::sync::atomic::Ordering::Relaxed);
+        *last_activity.lock().await = Instant::now();
+    }
+    Ok(())
+}
+
+async fn keepalive_loop(
+    ws_tx: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    last_activity: Arc<Mutex<Instant>>,
+) -> std::io::Result<()> {
+    let mut ticker = interval(PING_INTERVAL);
+    ticker.tick().await;
+    loop {
+        ticker.tick().await;
+        let idle = Instant::now().duration_since(*last_activity.lock().await);
+        if idle >= IDLE_TIMEOUT {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "tunnel idle timeout",
+            ));
+        }
+        let mut tx = ws_tx.lock().await;
+        if tx
+            .send(Message::Ping(Bytes::from_static(b"slasha")))
+            .await
+            .is_err()
+        {
+            return Ok(());
+        }
+    }
+}
+
+fn io_other<E: std::fmt::Display>(e: E) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
+}

--- a/web/app/components/apps/services.tsx
+++ b/web/app/components/apps/services.tsx
@@ -2,9 +2,7 @@ import { useState, useMemo, useEffect, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Database,
-  Play,
   Square,
-  Clock,
   AlertCircle,
   CheckCircle2,
   XCircle,
@@ -16,8 +14,9 @@ import {
   Settings,
   ChevronDown,
   ChevronRight,
-  Globe,
-  GlobeLock,
+  Plug,
+  Copy,
+  Check,
   RotateCcw,
   RefreshCw,
 } from 'lucide-react';
@@ -28,13 +27,10 @@ import {
   useProvisionService,
   useStopService,
   useDeleteService,
-  useExposeService,
-  useUnexposeService,
   useRestartService,
   useRedeployService,
   type ResourcesPayload,
   type ServiceKindDefaultResources,
-  type ServiceWithExposure,
 } from '~/queries/services';
 import { Button } from '~/components/interface/button';
 import { ConfirmationDialog } from '~/components/interface/confirmation-dialog';
@@ -198,19 +194,18 @@ function ServiceRow({
   appSlug,
   onShowLogs,
 }: {
-  service: ServiceWithExposure;
+  service: Service;
   appSlug: string;
   onShowLogs: () => void;
 }) {
   const queryClient = useQueryClient();
   const stopService = useStopService();
   const deleteService = useDeleteService();
-  const unexposeService = useUnexposeService();
   const restartService = useRestartService();
   const redeployService = useRedeployService();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showConfig, setShowConfig] = useState(false);
-  const [showExposeModal, setShowExposeModal] = useState(false);
+  const [showConnectModal, setShowConnectModal] = useState(false);
 
   const handleStop = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -239,22 +234,6 @@ function ServiceRow({
       setShowDeleteConfirm(false);
     } catch (e) {
       toast.error('Failed to delete service: ' + e);
-    }
-  };
-
-  const handleUnexpose = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    try {
-      await unexposeService.mutateAsync({
-        appSlug,
-        serviceId: service.id,
-      });
-      toast.success('Removing host port binding. Service will restart.');
-      queryClient.invalidateQueries({
-        queryKey: ['apps', appSlug, 'services'],
-      });
-    } catch (err) {
-      toast.error('Failed to unexpose service: ' + err);
     }
   };
 
@@ -310,12 +289,6 @@ function ServiceRow({
             <span className="text-[11px] text-text-tertiary">
               Created {formatRelativeTime(service.created_at)}
             </span>
-            {service.exposure && (
-              <span className="text-[11px] inline-flex items-center gap-1 text-sky-400 bg-sky-400/10 px-1.5 py-0.5 rounded">
-                <Globe className="size-3" />
-                {service.exposure.bind_addr}:{service.exposure.host_port}
-              </span>
-            )}
           </HStack>
         </VStack>
 
@@ -328,28 +301,17 @@ function ServiceRow({
             color="neutral"
             onClick={onShowLogs}
           />
-          {service.status === 'Running' && !service.exposure && (
+          {service.status === 'Running' && (
             <Button
-              label="Expose"
-              icon={<Globe className="size-3.5" />}
+              label="Connect"
+              icon={<Plug className="size-3.5" />}
               variant="ghost"
               size="sm"
               color="neutral"
               onClick={(e) => {
                 e.stopPropagation();
-                setShowExposeModal(true);
+                setShowConnectModal(true);
               }}
-            />
-          )}
-          {service.status === 'Running' && service.exposure && (
-            <Button
-              label="Unexpose"
-              icon={<GlobeLock className="size-3.5" />}
-              variant="ghost"
-              size="sm"
-              color="neutral"
-              onClick={handleUnexpose}
-              isLoading={unexposeService.isPending}
             />
           )}
           {(service.status === 'Running' || service.status === 'Stopped') && (
@@ -429,11 +391,11 @@ function ServiceRow({
         />
       )}
 
-      {showExposeModal && (
-        <ExposeServiceModal
+      {showConnectModal && (
+        <ConnectModal
           appSlug={appSlug}
           service={service}
-          onClose={() => setShowExposeModal(false)}
+          onClose={() => setShowConnectModal(false)}
         />
       )}
     </>
@@ -567,7 +529,6 @@ function ProvisionServiceModal({
   const [kindName, setKindName] = useState<ServiceKind | ''>('');
   const [version, setVersion] = useState<string>('');
   const [envVars, setEnvVars] = useState<Record<string, string>>({});
-  const [exposed, setExposed] = useState(false);
 
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
   const [memoryMb, setMemoryMb] = useState('');
@@ -618,7 +579,6 @@ function ProvisionServiceModal({
         name: name.trim(),
         version,
         envVars,
-        exposed,
         resources: payload,
       });
       queryClient.invalidateQueries({
@@ -683,35 +643,6 @@ function ProvisionServiceModal({
                   </option>
                 ))}
               </select>
-            </VStack>
-          </HStack>
-
-          <HStack
-            alignItems="center"
-            space={2}
-            className="cursor-pointer select-none"
-            onClick={() => setExposed(!exposed)}
-          >
-            <div
-              className={cn(
-                'flex h-4 w-7 shrink-0 items-center rounded-full px-0.5 transition-colors duration-200 ease-in-out',
-                exposed ? 'bg-emerald-500' : 'bg-surface-hover'
-              )}
-            >
-              <div
-                className={cn(
-                  'h-3 w-3 transform rounded-full bg-white shadow-sm transition duration-200 ease-in-out',
-                  exposed ? 'translate-x-3' : 'translate-x-0'
-                )}
-              />
-            </div>
-            <VStack space={0.5}>
-              <span className="text-xs font-medium text-text">
-                Expose Service
-              </span>
-              <p className="text-[10px] text-text-tertiary">
-                Assign an ephemeral host port for external access
-              </p>
             </VStack>
           </HStack>
 
@@ -869,31 +800,25 @@ function AdvancedResourcesSection({
   );
 }
 
-function ExposeServiceModal({
+function ConnectModal({
   appSlug,
   service,
   onClose,
 }: {
   appSlug: string;
-  service: ServiceWithExposure;
+  service: Service;
   onClose: () => void;
 }) {
-  const queryClient = useQueryClient();
-  const exposeService = useExposeService();
+  const command = `slasha proxy --app ${appSlug} ${service.name}`;
+  const [copied, setCopied] = useState(false);
 
-  const handleExpose = async () => {
+  const handleCopy = async () => {
     try {
-      await exposeService.mutateAsync({
-        appSlug,
-        serviceId: service.id,
-      });
-      toast.success('Exposing service on an auto-assigned host port.');
-      queryClient.invalidateQueries({
-        queryKey: ['apps', appSlug, 'services'],
-      });
-      onClose();
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
     } catch (e) {
-      toast.error('Failed to expose service: ' + e);
+      toast.error('Failed to copy: ' + e);
     }
   };
 
@@ -901,21 +826,37 @@ function ExposeServiceModal({
     <Dialog open={true} onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Expose {service.name}</DialogTitle>
+          <DialogTitle>Connect to {service.name}</DialogTitle>
         </DialogHeader>
         <VStack space={4} className="mt-4">
           <p className="text-xs text-text-tertiary">
-            Slasha will restart this service and let Docker assign an ephemeral
-            host port automatically.
+            Run this on your machine to open a secure tunnel to{' '}
+            {service.kind}. The tunnel rides the existing HTTPS connection — no
+            firewall rules required.
+          </p>
+          <div className="rounded-lg border border-border bg-black/40 p-3 font-mono text-[12px] text-text relative">
+            <code className="select-all break-all pr-10">{command}</code>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="absolute top-2 right-2 rounded p-1 text-text-tertiary hover:text-text hover:bg-white/5 transition-colors"
+              aria-label="Copy command"
+            >
+              {copied ? (
+                <Check className="size-3.5 text-emerald-400" />
+              ) : (
+                <Copy className="size-3.5" />
+              )}
+            </button>
+          </div>
+          <p className="text-[11px] text-text-tertiary">
+            The CLI prints the local port and a ready-to-paste connection
+            string. Use <code>--no-secret</code> to mask the password in shell
+            output.
           </p>
         </VStack>
         <DialogFooter className="mt-6">
-          <Button label="Cancel" variant="ghost" onClick={onClose} />
-          <Button
-            label="Expose"
-            onClick={handleExpose}
-            isLoading={exposeService.isPending}
-          />
+          <Button label="Close" variant="ghost" onClick={onClose} />
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/web/app/queries/services.ts
+++ b/web/app/queries/services.ts
@@ -23,15 +23,6 @@ export interface ServiceKindMeta {
   default_resources: ServiceKindDefaultResources;
 }
 
-export interface ServiceExposure {
-  host_port: number;
-  bind_addr: string;
-}
-
-export type ServiceWithExposure = Service & {
-  exposure: ServiceExposure | null;
-};
-
 export function getServiceKindsOptions() {
   return queryOptions({
     queryKey: ['services', 'kinds'],
@@ -42,8 +33,7 @@ export function getServiceKindsOptions() {
 export function getAppServicesOptions(appSlug: string) {
   return queryOptions({
     queryKey: ['apps', appSlug, 'services'],
-    queryFn: () =>
-      httpGet<{ services: ServiceWithExposure[] }>(`apps/${appSlug}/services`),
+    queryFn: () => httpGet<{ services: Service[] }>(`apps/${appSlug}/services`),
   });
 }
 
@@ -55,7 +45,6 @@ export function useProvisionService() {
       name: string;
       version: string;
       envVars: Record<string, string>;
-      exposed?: boolean;
       resources?: ResourcesPayload | null;
     }) =>
       httpPost<{ service: Service }>(`apps/${data.appSlug}/services`, {
@@ -63,7 +52,6 @@ export function useProvisionService() {
         name: data.name,
         version: data.version,
         env_vars: data.envVars,
-        exposed: data.exposed ?? false,
         resources: data.resources ?? null,
       }),
   });
@@ -104,25 +92,6 @@ export function useDeleteService() {
     mutationFn: (data: { appSlug: string; serviceId: string }) =>
       httpDelete<{ deleted: boolean }>(
         `apps/${data.appSlug}/services/${data.serviceId}`
-      ),
-  });
-}
-
-export function useExposeService() {
-  return useMutation({
-    mutationFn: (data: { appSlug: string; serviceId: string }) =>
-      httpPost<{ exposing: boolean }>(
-        `apps/${data.appSlug}/services/${data.serviceId}/expose`,
-        {}
-      ),
-  });
-}
-
-export function useUnexposeService() {
-  return useMutation({
-    mutationFn: (data: { appSlug: string; serviceId: string }) =>
-      httpDelete<{ unexposing: boolean }>(
-        `apps/${data.appSlug}/services/${data.serviceId}/expose`
       ),
   });
 }


### PR DESCRIPTION
## Summary
- Replaces the broken Expose-Service toggle (random ephemeral host port behind a closed ufw) with `slasha proxy <service>`, a CLI tunnel that rides the existing HTTPS connection
- New server endpoint `GET /api/apps/{slug}/services/{id}/tunnel` performs a WebSocket upgrade and splices binary frames to the service container's bridge-network IP; works without any firewall changes because slasha-server runs in host network mode
- The expose flow is gone: handlers, routes, `ServiceExposure`/`ServiceWithExposure`, `port_bindings`, and the `exposed` parameter threaded through the provision pipeline are all removed

## Why
The previous Expose toggle asked Docker for a random ephemeral host port but ufw only allows 22/80/443/2222, so nothing could actually connect to the published port from outside. The toggle was effectively dead. Rather than open the firewall (which would put DBs on the public internet under DB-only auth), this PR adds a proper CLI tunnel that reuses JWT auth and never publishes the DB port.

## Design notes
- Wire: WebSocket over HTTPS through the existing Caddy. One WS per accepted local TCP connection (no in-band multiplexing — simple, naturally cancellable)
- Backpressure: `copy_bidirectional`-style splice with a 16 KB read buffer; no unbounded queueing between the WS and TCP halves
- Idle handling: WS ping every 20s; 30-minute no-bytes idle timeout
- Limits: max 10 concurrent tunnels per user; audit log line at open/close with byte counters
- Reachability: server is on `network_mode: host` in prod, so it can route directly to bridge-network container IPs via `docker inspect` — no port publishing required
- CLI binds `127.0.0.1` only (no `--bind` flag, since exposing the tunnel on LAN bypasses Slasha auth)
- Passwords printed in the DSN by default; `--no-secret` masks them

## Test plan
- [ ] Provision a Postgres service, run `slasha proxy --app foo main-db`, connect with `psql` to the printed port, run `\dt` and a small query
- [ ] Same for MySQL, MongoDB, Redis
- [ ] `pg_dump | wc -c` of a moderately sized table to exercise TCP backpressure
- [ ] Open 11 simultaneous tunnels for the same user — 11th should be rejected
- [ ] Leave a tunnel idle 30+ minutes and confirm it closes; active connection during the 20s ping window stays alive
- [ ] `slasha provision` no longer accepts `--expose`; new dashboard Connect modal copies the right command