### PR TITLE
fix(deploy): override buildpack entrypoint for custom start commands

### DIFF
--- a/crates/slasha-server/src/docker/deployment/container.rs
+++ b/crates/slasha-server/src/docker/deployment/container.rs
@@ -218,6 +218,20 @@ pub async fn create_process_container(
         },
     );
 
+    // Buildpack images often set an entrypoint like ["/bin/bash", "-c"] that
+    // swallows our arguments: docker would run `/bin/bash -c sh -c <script>`,
+    // where `bash -c` keeps only `sh` as the script and drops the rest. When we
+    // supply a command, override the entrypoint and pass the command as a single
+    // argument (mirrors the cron runner). With no command, fall back to the
+    // image's own entrypoint and cmd.
+    let (entrypoint, container_cmd) = match cmd {
+        Some(c) => (
+            Some(vec!["sh".to_string(), "-c".to_string()]),
+            Some(vec![c]),
+        ),
+        None => (None, None),
+    };
+
     docker_client
         .create_container(
             Some(CreateContainerOptions {
@@ -228,7 +242,8 @@ pub async fn create_process_container(
                 image: Some(image_tag(&app.slug, &deployment.commit_sha)),
                 labels: Some(labels),
                 env,
-                cmd: cmd.map(|c| vec!["sh".to_string(), "-c".to_string(), c]),
+                entrypoint,
+                cmd: container_cmd,
                 host_config: Some(HostConfig {
                     restart_policy: Some(match context.process_type {
                         ProcessType::Release => RestartPolicy {


### PR DESCRIPTION
## Problem

Buildpack (railpack) images ship `ENTRYPOINT ["/bin/bash","-c"]` with `CMD ["node server.js"]`. When a deploy supplies a custom start command — a Procfile process, or the Litestream replication wrapper — `create_process_container` set the container `cmd` to `["sh","-c",<script>]` but left the image entrypoint intact, so docker ran:

```
/bin/bash -c sh -c <script>
```

`bash -c` keeps only its first argument (`sh`) as the script and drops the rest, so it ran a bare `sh` that read nothing and exited 0 — an invisible crash loop (exit 0, empty logs).

### Impact

Litestream backups were silently disabled for every app with a custom start command: the wrapped container never ran, so nothing replicated. The backup status could still show green because the periodic probe only lists the S3 replica path.

## Fix

Override the entrypoint to `["sh","-c"]` and pass the command as a single arg whenever a command is present — mirroring the cron runner fix in d2aa4c7 (`runner.rs:272`). With no command, fall back to the image's own entrypoint/cmd.

## Verification

- `cargo check -p slasha-server` passes.
- Reproduced the exit-0 crash loop with the image entrypoint; confirmed clearing the entrypoint runs the script.
- End-to-end Litestream DR test (sync to R2 → restore into a fresh volume) passes with this launch path.