### PR TITLE
fix(db): run migrations with foreign keys explicitly off

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4910,6 +4910,7 @@ dependencies = [
  "serde_json",
  "strum 0.28.0",
  "strum_macros 0.28.0",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/slasha-cli/src/clap_app.rs
+++ b/crates/slasha-cli/src/clap_app.rs
@@ -44,6 +44,15 @@ pub enum Command {
     #[command(name = "git-ssh", hide = true)]
     GitSsh { user_id: String },
 
+    #[command(name = "migrate-check", hide = true)]
+    MigrateCheck {
+        #[arg(long, value_name = "PATH")]
+        sqlite: String,
+
+        #[arg(long, value_name = "PATH")]
+        duckdb: String,
+    },
+
     #[command(name = "status", about = "Check server health")]
     Status,
 

--- a/crates/slasha-cli/src/main.rs
+++ b/crates/slasha-cli/src/main.rs
@@ -64,6 +64,13 @@ async fn run(cli: ClapApp) -> anyhow::Result<i32> {
         anyhow::bail!("No command provided. Run `slasha --help` for usage.");
     };
 
+    // Before AppState so the check needs no API config.
+    if let Command::MigrateCheck { sqlite, duckdb } = &command {
+        slasha_db::migrations::run_migrations(sqlite, duckdb);
+        cli_success("migrations applied cleanly");
+        return Ok(0);
+    }
+
     let state = AppState {
         api_client: ApiClient::from_config()?.with_url_override(url),
         output_mode,
@@ -74,6 +81,8 @@ async fn run(cli: ClapApp) -> anyhow::Result<i32> {
         Command::Serve => slasha_server::serve().await?,
         #[cfg(feature = "serve")]
         Command::GitSsh { user_id } => return git_ssh::handle(user_id).await,
+
+        Command::MigrateCheck { .. } => unreachable!("handled before AppState"),
 
         Command::Status => auth::handle_status(&state).await?,
         Command::Login => auth::handle_login(&state).await?,

--- a/crates/slasha-db/Cargo.toml
+++ b/crates/slasha-db/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2024"
 bundled-sqlite = ["libsqlite3-sys/bundled"]
 bundled-duckdb = ["duckdb/bundled"]
 
+[dev-dependencies]
+tempfile = "3.27.0"
+
 [dependencies]
 diesel = { version = "2.2.0", features = ["sqlite", "returning_clauses_for_sqlite_3_35", "r2d2", "chrono"] }
 diesel_migrations = "2.2.0"

--- a/crates/slasha-db/src/connection.rs
+++ b/crates/slasha-db/src/connection.rs
@@ -26,9 +26,8 @@ impl CustomizeConnection<SqliteConnection, Error> for SqliteConnectionCustomizer
             .execute(conn)
             .map_err(Error::QueryError)?;
 
-        // Enforce foreign keys so ON DELETE CASCADE actually fires; SQLite leaves
-        // this off per connection by default. Migrations use a separate, un-enforced
-        // connection (see run_migrations) so table rebuilds don't cascade-delete.
+        // Enforce foreign keys so ON DELETE CASCADE actually fires. Migrations use a
+        // separate connection that turns it off (see connect_for_migrations).
         diesel::sql_query("PRAGMA foreign_keys=ON;")
             .execute(conn)
             .map_err(Error::QueryError)?;

--- a/crates/slasha-db/src/migrations.rs
+++ b/crates/slasha-db/src/migrations.rs
@@ -11,19 +11,29 @@ pub const SQLITE_MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations/
 #[folder = "migrations/duckdb"]
 struct DuckDbMigrations;
 
-pub fn run_migrations(sqlite_db_path: &str, duckdb_path: &str) {
-    info!("Running SQLite migrations...");
-    // migrations run on a dedicated connection that leaves foreign keys at SQLite's
-    // default (off). The runtime pool enforces them, but a table-rebuild migration
-    // under enforcement would cascade-delete rows, so migrations must not enforce.
+fn connect_for_migrations(sqlite_db_path: &str) -> SqliteConnection {
     let mut conn = SqliteConnection::establish(sqlite_db_path)
         .expect("Failed to connect to SQLite for migrations");
+
+    // Can't be left to SQLite's default: vendored builds link libsqlite3-sys with
+    // -DSQLITE_DEFAULT_FOREIGN_KEYS=1, and enforced migrations cascade-delete on
+    // table rebuilds and reject ADD COLUMN ... REFERENCES on non-empty tables.
+    diesel::sql_query("PRAGMA foreign_keys=OFF;")
+        .execute(&mut conn)
+        .expect("Failed to disable SQLite foreign keys for migrations");
 
     // Wait out a competing writer rather than panicking the whole boot with
     // "database is locked" if the runtime pool is already touching the file.
     diesel::sql_query("PRAGMA busy_timeout=5000;")
         .execute(&mut conn)
         .expect("Failed to set SQLite busy_timeout for migrations");
+
+    conn
+}
+
+pub fn run_migrations(sqlite_db_path: &str, duckdb_path: &str) {
+    info!("Running SQLite migrations...");
+    let mut conn = connect_for_migrations(sqlite_db_path);
 
     let sqlite_pending = conn
         .pending_migrations(SQLITE_MIGRATIONS)
@@ -95,5 +105,91 @@ pub fn run_migrations(sqlite_db_path: &str, duckdb_path: &str) {
         info!("Applied {} DuckDB migrations successfully", duckdb_pending);
     } else {
         info!("No DuckDB migrations to apply");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use diesel::{QueryableByName, sql_types::BigInt};
+
+    use super::*;
+
+    #[derive(QueryableByName)]
+    struct Count {
+        #[diesel(sql_type = BigInt)]
+        n: i64,
+    }
+
+    fn count(conn: &mut SqliteConnection, query: &str) -> i64 {
+        diesel::sql_query(query)
+            .load::<Count>(conn)
+            .unwrap_or_else(|e| panic!("Failed to run {query}: {e:?}"))
+            .first()
+            .map(|row| row.n)
+            .unwrap_or_default()
+    }
+
+    const SEEDS: &[&str] = &[
+        "INSERT OR IGNORE INTO apps (id, slug, name, repo_path)
+         VALUES ('app-1', 'demo', 'Demo', '/tmp/demo');",
+        "INSERT OR IGNORE INTO deployments (id, app_id, commit_sha, commit_message, status)
+         VALUES ('dep-1', 'app-1', 'abc123', 'seed', 'running');",
+    ];
+
+    // Failures are expected: a table is only seedable once its migration has run.
+    fn seed(conn: &mut SqliteConnection) {
+        for statement in SEEDS {
+            let _ = diesel::sql_query(*statement).execute(conn);
+        }
+    }
+
+    // SQLite only rejects ADD COLUMN ... REFERENCES on a table that already has
+    // rows, so migrations must be stepped through with data present to catch it.
+    #[test]
+    fn migrations_apply_to_a_populated_database() {
+        let dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let db_path = dir.path().join("test.db");
+        let db_path = db_path.to_str().expect("Invalid temp path");
+
+        let mut conn = connect_for_migrations(db_path);
+
+        let pending = conn
+            .pending_migrations(SQLITE_MIGRATIONS)
+            .expect("Failed to collect pending migrations");
+
+        assert!(!pending.is_empty(), "expected migrations to run");
+
+        for migration in pending {
+            conn.run_migration(&migration).unwrap_or_else(|e| {
+                panic!(
+                    "migration {} failed against a populated database: {:?}",
+                    migration.name(),
+                    e
+                )
+            });
+
+            seed(&mut conn);
+        }
+
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) AS n FROM apps;"),
+            1,
+            "seed rows were never inserted"
+        );
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) AS n FROM deployments;"),
+            1,
+            "seed rows were never inserted"
+        );
+
+        diesel::sql_query("PRAGMA foreign_keys=ON;")
+            .execute(&mut conn)
+            .expect("Failed to enable foreign keys");
+
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) AS n FROM pragma_foreign_key_check;"),
+            0,
+            "migrations left foreign key violations"
+        );
     }
 }


### PR DESCRIPTION
The deploy of d4ce276 crash-looped on boot:

```
Failed to run SQLite migrations: ... "2026-07-08-145703-0000_create_nodes_table"
DatabaseError(Unknown, "Cannot add a REFERENCES column with non-NULL default value")
```

Turns out migrations were running with foreign keys enforced, even though the comment said otherwise. `libsqlite3-sys` builds the bundled amalgamation with `-DSQLITE_DEFAULT_FOREIGN_KEYS=1`, and we pull that in via `vendored` in the default features.

With enforcement on, SQLite refuses `ADD COLUMN ... NOT NULL DEFAULT ... REFERENCES` — but only if the table already has rows. That's why it went unnoticed: fine on a fresh DB, fine in CI, broken on prod. The migration had never actually applied there.

Fix is to set the pragma explicitly instead of relying on the build default.

Added a test that walks the migrations one at a time against a DB with rows in it, which fails with the same error if you revert the pragma. Also added a hidden `migrate-check` command so deploys can run migrations against a copy of the live DB before swapping the container — see the matching change in slasha-infra.

One thing worth flagging separately: foreign keys have been enforced during every migration in vendored builds, so any past table rebuild ran with cascades live.