### PR TITLE
fix(build): drop phantom BuildKit session so builds work on Docker 29.6.2

### DIFF
--- a/crates/slasha-server/src/docker/deployment/build.rs
+++ b/crates/slasha-server/src/docker/deployment/build.rs
@@ -117,14 +117,18 @@ async fn build_image_from_tar(
 ) -> DeploymentResult<()> {
     let tar_body_stream = body_stream(stream::once(async move { tar_bytes }));
 
-    let session_id = uuid::Uuid::new_v4().to_string();
+    // bollard's `build_image` is a plain HTTP POST and never opens a BuildKit
+    // gRPC session, so don't declare one. A phantom `session` makes the daemon
+    // route local-source access through that never-connected session and fail
+    // ("no local sources enabled" on Docker >= 29.6.2; silently tolerated on
+    // 29.6.1). Omitting it makes the daemon use the uploaded tar as the build
+    // context; the `# syntax=` frontend is still resolved server-side.
     let build_opts = BuildImageOptionsBuilder::new()
         .t(image_tag)
         .dockerfile(dockerfile)
         .rm(true)
         .forcerm(true)
         .version(BuilderVersion::BuilderBuildKit)
-        .session(&session_id)
         .build();
 
     let mut build_stream = docker_client.build_image(build_opts, None, Some(tar_body_stream));


### PR DESCRIPTION
## Problem

App deploys fail during the BuildKit build step with:

```
Docker error during build: Docker stream error: no local sources enabled
Deployment failed: Docker API error: Docker stream error: no local sources enabled
```

This started when a host runs Docker 29.6.2. Docker 29.6.1 builds fine (the currently-running prod app was built on 29.6.1).

## Root cause

`build_image_from_tar` (crates/slasha-server/src/docker/deployment/build.rs) passed a random `session` id to bollard's `build_image`:

```rust
let session_id = uuid::Uuid::new_v4().to_string();
let build_opts = BuildImageOptionsBuilder::new()
    ...
    .session(&session_id)   // <- never actually connected
    .build();
```

But `build_image` is a plain HTTP `POST /build` — it never opens the BuildKit gRPC session that a `session` id implies. Declaring one tells the daemon to fetch the build context (local sources) over that session via `filesync`. Since nothing connects, the daemon has no local sources.

- Docker 29.6.1: tolerated this and silently fell back to the uploaded tar as the context.
- Docker 29.6.2: no longer falls back — it fails with `no local sources enabled` (emitted from moby/buildkit `session/filesync/filesync.go`).

## Fix

Remove the phantom `.session()`. With no session declared, the daemon uses the uploaded tar as the build context. The `# syntax=ghcr.io/railwayapp/railpack-frontend` frontend is still resolved server-side, so railpack builds are unaffected.

## Verification

- `cargo check -p slasha-server` passes.
- Reproduced against a live Docker 29.6.2 daemon with the exact call shape: `POST /build?version=2` with a `session` param fails (`no active session ... deadline exceeded` / `no local sources enabled`); the identical request without the `session` param builds the image successfully, `# syntax=` frontend and all.

Fixes both build paths (`build_railpack` and `build_docker`) since both go through `build_image_from_tar`.